### PR TITLE
Feat: tid-first sched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ draft/
 
 perf.data*
 *.data
+
+.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             // Resolved by CMake Tools:
             "program": "${command:cmake.launchTargetPath}",
-            "args": ["build/example/rand4kr", "/tmp/test_randread", "3000000"],
+            "args": ["build/example/rand4kr", "draft/man", "10000000"],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ int main(int argc, const char *argv[]) {
 1. **co_context** 的主线程和任意 worker 的数据交换中没有使用互斥锁，极少使用原子变量。
 2. **co_context** 的数据结构保证「可能频繁读写」的 cacheline 最多被两个线程访问，无论并发强度有多大。这个保证本身也不经过互斥锁或原子变量。（若使用原子变量，高竞争下性能损失约 33%～70%）
 3. 对于可能被多于两个线程读写的 cacheline，**co_context** 保证乒乓缓存问题最多发生常数次。
-4. 在 AMD-5800X，3200 Mhz-ddr4 环境下，若绕过 io_uring，**co_context** 的线程交互频率可达 1.25 GHz。（线程数=6，swap_slots=256，0.980 s 内完成1.25 G 次生产消费）
-5. 协程自身的缓存不友好问题（主要由 `operator new` 引起），需要借助其他工具来解决，例如 [mimalloc](https://github.com/microsoft/mimalloc)。
+4. 在 AMD-5800X，3200 Mhz-ddr4 环境下，若绕过 io_uring，**co_context** 的线程交互频率可达 1.25 GHz。
+5. 创建、运行、销毁高竞争协程的频率可达 58 M（线程数=4，swap_capacity=32768，0.986 s 内完成 58 M 原子变量自增），代码见 example/nop.cpp。
+6. 协程自身的缓存不友好问题（主要由 `operator new` 引起），需要借助其他工具来解决，例如 [mimalloc](https://github.com/microsoft/mimalloc)。
 
 ---
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -16,5 +16,14 @@ target_link_libraries(rand4kr PUBLIC mimalloc)
 add_executable(rand4kr_blocking rand4kr_blocking.cpp)
 target_link_libraries(rand4kr_blocking PUBLIC mimalloc)
 
+add_executable(rand4kr_callback rand4kr_callback.cpp)
+target_link_libraries(rand4kr_callback PUBLIC mimalloc)
+
+add_executable(rand4kw_callback rand4kw_callback.cpp)
+target_link_libraries(rand4kw_callback PUBLIC mimalloc)
+
 add_executable(nop nop.cpp)
 target_link_libraries(nop PUBLIC mimalloc)
+
+add_executable(nop_thread nop_thread.cpp)
+

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -15,3 +15,6 @@ target_link_libraries(rand4kr PUBLIC mimalloc)
 
 add_executable(rand4kr_blocking rand4kr_blocking.cpp)
 target_link_libraries(rand4kr_blocking PUBLIC mimalloc)
+
+add_executable(nop nop.cpp)
+target_link_libraries(nop PUBLIC mimalloc)

--- a/example/netcat.cpp
+++ b/example/netcat.cpp
@@ -49,7 +49,7 @@ co_context::main_task run(co_context::socket peer) {
     int nr = 0;
     // 不断接收字节流
     while ((nr = co_await peer.recv(buf, 0)) > 0) {
-        co_await lazy::write(STDOUT_FILENO, {buf, (size_t)nr}, 0);
+        // co_await lazy::write(STDOUT_FILENO, {buf, (size_t)nr}, 0);
         
         // int nw = write_n(STDOUT_FILENO, buf, nr); // 将收到的字节全部打印到 stdout
         // if (nw < nr) break;

--- a/example/netcat.cpp
+++ b/example/netcat.cpp
@@ -48,6 +48,7 @@ co_context::main_task run(co_context::socket peer) {
     char buf[8192];
     int nr = 0;
     // 不断接收字节流
+    // while ((nr = ::recv(peer.fd(), buf, 8192, 0)) > 0) {}
     while ((nr = co_await peer.recv(buf, 0)) > 0) {
         // co_await lazy::write(STDOUT_FILENO, {buf, (size_t)nr}, 0);
         

--- a/example/nop.cpp
+++ b/example/nop.cpp
@@ -1,0 +1,46 @@
+#include <mimalloc-new-delete.h>
+#include "co_context.hpp"
+#include "co_context/net/acceptor.hpp"
+#include "co_context/buffer.hpp"
+
+#include <filesystem>
+#include <random>
+#include <fcntl.h>
+#include <atomic>
+#include <chrono>
+
+using namespace co_context;
+
+int times;
+std::atomic_int finish = 0;
+constexpr int concur = 3;
+
+main_task run() {
+    if (finish.fetch_add(1) + 1 == times) {
+        printf("All done!\n");
+        ::exit(0);
+    }
+    co_await eager::nop();
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        printf("Usage:\n  %s times\n", argv[0]);
+        return 0;
+    }
+
+    times = atoi(argv[1]);
+    times -= times % concur;
+
+    io_context context{256};
+
+    for (int i = 0; i < concur; ++i)
+        context.co_spawn([]() -> main_task {
+            for (int i = 0; i < times / concur; ++i) { co_spawn(run()); }
+            co_await eager::nop();
+        }());
+
+    context.run();
+
+    return 0;
+}

--- a/example/nop_thread.cpp
+++ b/example/nop_thread.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+int times;
+std::atomic_int finish = 0;
+constexpr int concur = 2;
+
+void workload() {
+    for (int i=0; i<times/concur; ++i) {
+        int now = finish.fetch_add(1) + 1;
+        if (now == times) {
+            printf("All done!\n");
+        }
+    }
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        printf("Usage:\n  %s times\n", argv[0]);
+        return 0;
+    }
+
+    times = atoi(argv[1]);
+    times -= times % concur;
+
+    std::vector<std::jthread> v;
+    for (int i=0; i<concur; ++i) {
+        v.emplace_back(workload);
+    }
+
+    return 0;
+}

--- a/example/rand4kr.cpp
+++ b/example/rand4kr.cpp
@@ -18,7 +18,8 @@ std::atomic_int finish;
 std::atomic_int alive;
 
 constexpr size_t BLOCK_LEN = 4096;
-constexpr int MAX_ON_FLY = 30000000;
+constexpr int MAX_ON_FLY = 16000000;
+
 
 main_task run(size_t offset) {
     char buf[BLOCK_LEN];
@@ -32,9 +33,9 @@ main_task run(size_t offset) {
     };
 
     int nr;
-    nr = co_await lazy::read(file_fd, buf, offset);
+    // nr = co_await lazy::read(file_fd, buf, offset);
     // nr = ::pread(file_fd, buf, BLOCK_LEN, offset);
-    // co_await eager::nop();
+    co_await eager::nop();
 
     int now = finish.fetch_add(1) + 1;
     alive.fetch_sub(1);
@@ -64,13 +65,13 @@ int main(int argc, char *argv[]) {
 
     alive.store(0);
     context.co_spawn([]() -> main_task {
-        std::mt19937_64 rng(0);
+        // std::mt19937_64 rng(0);
         for (int i = 0; i < times; ++i) {
-            const size_t offset = (rng() % file_size) & ~(BLOCK_LEN - 1);
-            while (alive.load(std::memory_order_relaxed) >= MAX_ON_FLY)
-                co_await yield();
-            alive.fetch_add(1);
-            co_spawn(run(offset));
+            // const size_t offset = (rng() % file_size) & ~(BLOCK_LEN - 1);
+        //     while (alive.load(std::memory_order_relaxed) >= MAX_ON_FLY)
+        //         co_await yield();
+        //     alive.fetch_add(1);
+            // co_spawn(run(offset));
         }
         co_await eager::nop();
     }());

--- a/example/rand4kr.cpp
+++ b/example/rand4kr.cpp
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <atomic>
 #include <chrono>
+#include <semaphore>
 
 using namespace co_context;
 
@@ -18,8 +19,15 @@ std::atomic_int finish;
 std::atomic_int alive;
 
 constexpr size_t BLOCK_LEN = 4096;
-constexpr int MAX_ON_FLY = 16000000;
+constexpr int MAX_ON_FLY = 16;
+std::counting_semaphore<MAX_ON_FLY> sem{MAX_ON_FLY};
+char zero[BLOCK_LEN];
 
+void gen(char (&buf)[BLOCK_LEN]) {
+    static std::mt19937 rng(0);
+    for (int i = 0; i < BLOCK_LEN - 1; ++i) { buf[i] = rng() % 26 + 'a'; }
+    buf[BLOCK_LEN - 1] = '\n';
+}
 
 main_task run(size_t offset) {
     char buf[BLOCK_LEN];
@@ -32,46 +40,59 @@ main_task run(size_t offset) {
 #endif
     };
 
-    int nr;
-    // nr = co_await lazy::read(file_fd, buf, offset);
-    // nr = ::pread(file_fd, buf, BLOCK_LEN, offset);
+    // int nr = co_await lazy::read(file_fd, buf, offset);
+    gen(buf);
+    int nw =
+        co_await lazy::write(file_fd, buf, finish.load() % 300000 * BLOCK_LEN);
+    // int nw = ::write(file_fd, buf, BLOCK_LEN);
+    if (nw < 0) { perror("write"); }
+    // printf("%d\n", nw);
+    // buf[15] = '\0';
+    // printf("%s", buf);
+    // printf("%lu\n", offset);
     co_await eager::nop();
 
     int now = finish.fetch_add(1) + 1;
-    alive.fetch_sub(1);
+    sem.release();
+    // alive.fetch_sub(1);
     // printf("now = %d\n", now);
     if (now == times) {
         printf("All done\n");
+        ::close(file_fd);
         ::exit(0);
     }
 }
 
 int main(int argc, char *argv[]) {
+    memset(zero, 'x', sizeof(zero));
+
     finish.store(0);
     if (argc < 3) {
         printf("Usage:\n  %s file times [file size]\n", argv[0]);
         return 0;
     }
 
-    file_fd = ::open(argv[1], O_RDONLY);
+    file_fd = ::open(argv[1], O_RDWR | O_TRUNC);
     if (file_fd < 0) {
         throw std::system_error{errno, std::system_category(), "open"};
     }
 
     times = atoi(argv[2]);
-    file_size = argc == 4 ? atoll(argv[3]) : 1'000'000'000;
+    file_size = argc == 4 ? atoll(argv[3]) : 60'000'000;
+    // file_size = argc == 4 ? atoll(argv[3]) : 3'000'000'000;
 
     io_context context{256};
 
     alive.store(0);
     context.co_spawn([]() -> main_task {
-        // std::mt19937_64 rng(0);
+        std::mt19937_64 rng(0);
         for (int i = 0; i < times; ++i) {
-            // const size_t offset = (rng() % file_size) & ~(BLOCK_LEN - 1);
-        //     while (alive.load(std::memory_order_relaxed) >= MAX_ON_FLY)
-        //         co_await yield();
-        //     alive.fetch_add(1);
-            // co_spawn(run(offset));
+            const size_t offset = (rng() % file_size) & ~(BLOCK_LEN - 1);
+            // while (alive.load(std::memory_order_relaxed) >= MAX_ON_FLY)
+            //     co_await yield();
+            // alive.fetch_add(1);
+            sem.acquire();
+            co_spawn(run(offset));
         }
         co_await eager::nop();
     }());

--- a/example/rand4kr_blocking.cpp
+++ b/example/rand4kr_blocking.cpp
@@ -32,6 +32,8 @@ main_task run(size_t offset) {
     int nr;
     // nr = co_await lazy::read(file_fd, buf, offset);
     nr = ::pread(file_fd, buf, BLOCK_LEN, offset);
+    // buf[15] = '\0';
+    // printf("%lu %s", offset, buf);
     co_await eager::nop();
 
     int now = finish.fetch_add(1) + 1;

--- a/example/rand4kr_callback.cpp
+++ b/example/rand4kr_callback.cpp
@@ -1,0 +1,79 @@
+#include <mimalloc-new-delete.h>
+#include "co_context.hpp"
+#include "co_context/net/acceptor.hpp"
+#include "co_context/buffer.hpp"
+
+#include <filesystem>
+#include <random>
+#include <fcntl.h>
+#include <atomic>
+#include <chrono>
+#include <semaphore>
+
+using namespace co_context;
+
+int file_fd;
+size_t file_size;
+int times;
+std::atomic_int alive = 0, finish = 0;
+
+constexpr size_t BLOCK_LEN = 4096;
+constexpr int MAX_ON_FLY = 24; // 3 worker thread
+// constexpr int MAX_ON_FLY = 2; // 1 worker thread
+
+char buf[4][BLOCK_LEN];
+std::mt19937_64 rng(0);
+
+main_task run() {
+    log::d("r4kr at ?? run()\n");
+    const uint32_t tid = co_get_tid();
+    const int32_t pid = ::gettid();
+    log::d("r4kr at [%u](%d) run()\n", tid, pid);
+
+    const size_t idx = alive.fetch_add(1);
+    log::d("r4kr at [%u](%d) read()\n", tid, pid);
+    const size_t off = (rng() % file_size) & ~(BLOCK_LEN - 1);
+    // const size_t off = (idx % file_size) & ~(BLOCK_LEN - 1);
+    int nr = co_await lazy::read(file_fd, buf[tid], off);
+    if (nr < 0) { perror("read err"); }
+
+    int now = finish.fetch_add(1) + 1;
+    if (now == times) [[unlikely]] {
+        printf("All done\n");
+        co_context_stop();
+        ::close(file_fd);
+        ::exit(0);
+    } else if (idx + 1 < times) [[likely]] {
+        log::d("r4kr at [%u](%d) callback\n", tid, pid);
+        auto t = run();
+        log::d("r4kr at [%u](%d) spawn ready\n", tid, pid);
+        co_spawn(t);
+        log::d("r4kr at [%u](%d) spawn end\n", tid, pid);
+    }
+    log::d("r4kr at [%u](%d) end\n", tid, pid);
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 3) {
+        printf("Usage:\n  %s file times [file size]\n", argv[0]);
+        return 0;
+    }
+
+    file_fd = ::open(argv[1], O_RDONLY);
+    if (file_fd < 0) {
+        throw std::system_error{errno, std::system_category(), "open"};
+    }
+
+    times = atoi(argv[2]);
+    // file_size = argc == 4 ? atoll(argv[3]) : 60'000'000;
+    file_size = argc == 4 ? atoll(argv[3]) : 1'000'000'000;
+
+    io_context context{256};
+
+    for (int i = 0; i < std::min(MAX_ON_FLY, times); ++i)
+        context.co_spawn(run());
+
+    context.run();
+
+    return 0;
+}

--- a/example/rand4kw_callback.cpp
+++ b/example/rand4kw_callback.cpp
@@ -1,0 +1,91 @@
+#include <mimalloc-new-delete.h>
+#include "co_context.hpp"
+#include "co_context/net/acceptor.hpp"
+#include "co_context/buffer.hpp"
+
+#include <filesystem>
+#include <random>
+#include <fcntl.h>
+#include <atomic>
+#include <chrono>
+#include <semaphore>
+
+using namespace co_context;
+
+int file_fd;
+size_t file_size;
+int times;
+std::atomic_int alive, finish;
+
+constexpr size_t BLOCK_LEN = 4096;
+constexpr int MAX_ON_FLY = 12; // 3 worker thread
+// constexpr int MAX_ON_FLY = 2; // 1 worker thread
+char zero[BLOCK_LEN];
+char buf[BLOCK_LEN];
+std::mt19937_64 rng(0);
+
+void gen(char (&buf)[BLOCK_LEN]) {
+    static std::mt19937 rng(0);
+    for (int i = 0; i < BLOCK_LEN - 1; ++i) { buf[i] = rng() % 26 + 'a'; }
+    buf[BLOCK_LEN - 1] = '\n';
+}
+
+main_task run() {
+    log::d("r4kw at ?? run()\n");
+    const uint32_t tid = co_get_tid();
+    const int32_t pid = ::gettid();
+    log::d("r4kw at [%u](%d) run()\n", tid, pid);
+
+    const size_t idx = alive.fetch_add(1);
+    log::d("r4kw at [%u] write()\n", tid);
+    const size_t off = (rng() % file_size) & ~(BLOCK_LEN - 1);
+    // const size_t off = (idx % file_size) & ~(BLOCK_LEN - 1);
+    int nw = co_await lazy::write(file_fd, buf, off);
+    // log::d("r4kw at [%u] fsync()\n", tid);
+    // int res = co_await lazy::fsync(file_fd, IORING_FSYNC_DATASYNC);
+    if (nw < 0) { perror("write err"); }
+
+    int now = finish.fetch_add(1) + 1;
+    if (now == times) [[unlikely]] {
+        printf("All done\n");
+        co_context_stop();
+        ::close(file_fd);
+        ::exit(0);
+    } else if (idx + 1 < times) [[likely]] {
+        log::d("r4kw at [%u](%d) callback\n", tid, pid);
+        auto t = run();
+        log::d("r4kw at [%u](%d) spawn ready\n", tid, pid);
+        co_spawn(t);
+        log::d("r4kw at [%u](%d) spawn end\n", tid, pid);
+    }
+    log::d("r4kw at [%u](%d) end\n", tid, pid);
+}
+
+int main(int argc, char *argv[]) {
+    memset(zero, 'x', sizeof(zero));
+    gen(buf);
+
+    finish.store(0);
+    if (argc < 3) {
+        printf("Usage:\n  %s file times [file size]\n", argv[0]);
+        return 0;
+    }
+
+    file_fd = ::open(argv[1], O_WRONLY);
+    if (file_fd < 0) {
+        throw std::system_error{errno, std::system_category(), "open"};
+    }
+
+    times = atoi(argv[2]);
+    // file_size = argc == 4 ? atoll(argv[3]) : 60'000'000;
+    file_size = argc == 4 ? atoll(argv[3]) : 1'000'000'000;
+
+    io_context context{256};
+
+    for (int i = 0; i < std::min(MAX_ON_FLY, times); ++i)
+        context.co_spawn(run());
+
+    context.run();
+
+    return 0;
+}

--- a/include/co_context.hpp
+++ b/include/co_context.hpp
@@ -289,7 +289,7 @@ class [[nodiscard]] io_context final {
         }
     }
 
-    bool try_clear_submit_overflow_buf() noexcept {
+    inline bool try_clear_submit_overflow_buf() noexcept {
         while (!submit_overflow_buf.empty()) {
             task_info_ptr task = submit_overflow_buf.front();
             // OPTIMIZE impossible for task_type::co_spawn
@@ -332,7 +332,7 @@ class [[nodiscard]] io_context final {
         }
     }
 
-    bool try_clear_reap_overflow_buf() noexcept {
+    inline bool try_clear_reap_overflow_buf() noexcept {
         while (!reap_overflow_buf.empty()) {
             task_info_ptr task = reap_overflow_buf.front();
             // OPTIMIZE impossible for task_type::co_spawn
@@ -409,18 +409,18 @@ class [[nodiscard]] io_context final {
         make_thread_pool();
 
         while (true) {
-            if (try_clear_submit_overflow_buf()) {
+            if (try_clear_submit_overflow_buf())
                 for (uint8_t i = 0; i < config::submit_poll_rounds; ++i) {
                     if (!poll_submission()) break;
                     // poll_submission();
                 }
-            }
-            if (try_clear_reap_overflow_buf()) {
+
+            if (try_clear_reap_overflow_buf())
                 for (uint8_t i = 0; i < config::reap_poll_rounds; ++i) {
                     if (!poll_completion()) break;
                     // poll_completion();
                 }
-            }
+
             // std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
     }

--- a/include/co_context.hpp
+++ b/include/co_context.hpp
@@ -46,13 +46,23 @@ class io_context;
 // class eager_io;
 // class lazy_io;
 
+namespace config {
+    inline constexpr bool is_SQPOLL = io_uring_flags & IORING_SETUP_SQPOLL;
+
+    inline constexpr unsigned worker_threads_number =
+        total_threads_number - 1 - is_SQPOLL;
+} // namespace config
+
 namespace detail {
     class worker_meta;
+
+    using swap_zone =
+        task_info_ptr[config::worker_threads_number][config::swap_capacity];
 
     struct alignas(cache_line_size) thread_meta {
         io_context *ctx;
         worker_meta *worker;
-        int tid;
+        uint32_t tid;
     };
 
     inline static thread_local thread_meta this_thread;
@@ -62,14 +72,22 @@ namespace detail {
         /**
          * @brief sharing zone with main thread
          */
-        struct alignas(cache_line_size) {
+        struct sharing_zone {
+            std::thread host_thread;
             worker_state state; // TODO atomic?
             int temp;
         };
+
+        alignas(cache_line_size) sharing_zone sharing;
+
         struct swap_cur {
-            uint16_t slot = 0;
             uint16_t off = 0;
             void next() noexcept;
+            bool try_find_empty(swap_zone &swap) noexcept;
+            bool try_find_exist(swap_zone &swap) noexcept;
+            void release(swap_zone &swap, task_info_ptr task) const noexcept;
+            void
+            release_relaxed(swap_zone &swap, task_info_ptr task) const noexcept;
         };
         swap_cur submit_cur;
         swap_cur reap_cur;
@@ -101,47 +119,37 @@ namespace detail {
 
 } // namespace detail
 
+/*
 inline constexpr uint16_t task_info_number_per_cache_line =
     cache_line_size / sizeof(detail::task_info *);
+*/
 
 class [[nodiscard]] io_context final {
   public:
-    static constexpr unsigned io_uring_flags = config::io_uring_flags;
-
-    static constexpr unsigned total_threads_number =
-        config::total_threads_number;
-
-    static constexpr bool low_latency_mode = config::low_latency_mode;
-
+    /*
     static constexpr uint16_t swap_slots =
         config::swap_capacity / task_info_number_per_cache_line;
 
     static constexpr uint16_t task_info_number_per_thread =
         task_info_number_per_cache_line * swap_slots;
-
-    static constexpr bool is_SQPOLL = io_uring_flags & IORING_SETUP_SQPOLL;
+    */
 
     /**
      * One thread for io_context submit/reap. Another thread for io_uring (if
      * needed).
      */
-    static constexpr unsigned worker_threads_number =
-        total_threads_number - 1 - is_SQPOLL;
 
-    static_assert(worker_threads_number >= 1);
+    static_assert(config::worker_threads_number >= 1);
 
-    using uring = liburingcxx::URing<io_uring_flags>;
+    using uring = liburingcxx::URing<config::io_uring_flags>;
 
     using task_info = detail::task_info;
 
-    using swap_zone = task_info
-        *[swap_slots][worker_threads_number][task_info_number_per_cache_line];
+    using task_info_ptr = detail::task_info_ptr;
 
-    // Not necessary to read/write atomicly, since there is no order consistency
-    // problem.
-    /* using swap_zone =
-        std::atomic<task_info *>[swap_slots][worker_threads_number]
-                                [task_info_number_per_cache_line]; */
+    // May not necessary to read/write atomicly.
+    using swap_zone =
+        task_info_ptr[config::worker_threads_number][config::swap_capacity];
 
   private:
     alignas(cache_line_size) uring ring;
@@ -149,26 +157,77 @@ class [[nodiscard]] io_context final {
     alignas(cache_line_size) swap_zone reap_swap;
 
     struct ctx_swap_cur {
-        uint16_t slot = 0;
-        unsigned tid = 0;
+        uint16_t tid = 0;
         uint16_t off = 0;
 
         inline void next() {
-            if (++off == task_info_number_per_cache_line) [[unlikely]] {
-                off = 0;
-                if (++tid == worker_threads_number) [[unlikely]] {
-                    tid = 0;
-                    if (++slot == swap_slots) [[unlikely]] { slot = 0; }
-                }
+            if (++tid == config::worker_threads_number) [[unlikely]] {
+                tid = 0;
+                off = (off + 1) % config::swap_capacity;
             }
+        }
+
+        inline bool try_find_empty(const swap_zone &swap) noexcept {
+            constexpr uint32_t swap_size =
+                sizeof(swap_zone) / sizeof(task_info_ptr);
+            int i = 0;
+            while (i < swap_size && swap[tid][off] != nullptr) {
+                ++i;
+                next();
+            }
+            if (i != swap_size) [[likely]] {
+                return true;
+            } else {
+                next();
+                return false;
+            }
+        }
+
+        // inline void wait_for_empty(const swap_zone &swap) noexcept {
+        //     while (swap[tid][off] != nullptr) next();
+        // }
+
+        inline bool try_find_exist(const swap_zone &swap) noexcept {
+            constexpr uint32_t swap_size =
+                sizeof(swap_zone) / sizeof(task_info_ptr);
+            int i = 0;
+            while (i < swap_size && swap[tid][off] == nullptr) {
+                ++i;
+                next();
+            }
+            if (i != swap_size) [[likely]] {
+                return true;
+            } else {
+                next();
+                return false;
+            }
+        }
+
+        // inline void wait_for_exist(const swap_zone &swap) noexcept {
+        //     while (swap[tid][off] == nullptr) next();
+        // }
+
+        // release the task into the swap zone
+        inline void
+        release(swap_zone &swap, task_info_ptr task) const noexcept {
+            std::atomic_store_explicit(
+                reinterpret_cast<std::atomic<task_info_ptr> *>(&swap[tid][off]),
+                task, std::memory_order_release);
+        }
+
+        inline void
+        release_relaxed(swap_zone &swap, task_info_ptr task) const noexcept {
+            std::atomic_store_explicit(
+                reinterpret_cast<std::atomic<task_info_ptr> *>(&swap[tid][off]),
+                task, std::memory_order_relaxed);
         }
     };
 
+    // place main thread's high frequency data here
     ctx_swap_cur s_cur;
     ctx_swap_cur r_cur;
-    liburingcxx::CQEntry *polling_cqe = nullptr;
-    char
-        __padding0[cache_line_size - 2 * sizeof(ctx_swap_cur) - sizeof(void *)];
+    std::queue<task_info_ptr> submit_overflow_buf;
+    std::queue<task_info_ptr> reap_overflow_buf;
 
     // std::counting_semaphore<1> idle_worker_quota{1};
 
@@ -177,89 +236,112 @@ class [[nodiscard]] io_context final {
     friend worker_meta;
 
   private:
-    alignas(cache_line_size) worker_meta worker[worker_threads_number];
-
-    union alignas(cache_line_size) {
-        std::thread worker_threads[worker_threads_number];
-    };
-
-  public:
+    alignas(cache_line_size) worker_meta worker[config::worker_threads_number];
 
   private:
     const unsigned ring_entries;
-    int temp = 0;
 
   private:
-    void forward_task(task_info *task) noexcept {
-        while (reap_swap[r_cur.slot][r_cur.tid][r_cur.off] != nullptr)
+    void forward_task(task_info_ptr task) noexcept {
+        // TODO optimize scheduling strategy
+        if (r_cur.try_find_empty(reap_swap)) [[likely]] {
+            reap_swap[r_cur.tid][r_cur.off] = task;
             r_cur.next();
-        reap_swap[r_cur.slot][r_cur.tid][r_cur.off] = task;
-        r_cur.next();
+        } else {
+            reap_overflow_buf.push(task);
+        }
+    }
+
+    bool try_submit(task_info_ptr task) noexcept {
+        if (task->type == task_info::task_type::co_spawn) {
+            forward_task(task);
+            return true;
+        }
+
+        if (ring.SQSpaceLeft() == 0) [[unlikely]] {
+            return false; // SQRing is full
+        }
+
+        liburingcxx::SQEntry *sqe = ring.getSQEntry();
+
+        sqe->cloneFrom(*task->sqe);
+        ring.submit();
+        return true;
     }
 
     /**
      * @brief poll the submission swap zone
-     * @return if load exists and capacity is healthy
+     * @return if submit_swap capacity might be healthy
      */
     bool poll_submission() noexcept {
-        constexpr int swap_size = sizeof(swap_zone) / sizeof(task_info *);
         // submit round
-        int i = 0;
-        for (; i < swap_size; ++i) {
-            if (submit_swap[s_cur.slot][s_cur.tid][s_cur.off] != nullptr) break;
-            s_cur.next();
-        }
-        if (i == swap_size) return false;
-        task_info *io_info = submit_swap[s_cur.slot][s_cur.tid][s_cur.off];
-        submit_swap[s_cur.slot][s_cur.tid][s_cur.off] = nullptr;
+        if (!s_cur.try_find_exist(submit_swap)) return false;
 
-        if (io_info->type == task_info::task_type::co_spawn) {
-            forward_task(io_info);
-            s_cur.next();
-            return true;
-        }
-
-        if (ring.SQSpaceLeft() == 0) return false; // SQRing is full
-        liburingcxx::SQEntry *sqe = ring.getSQEntry();
-
-        sqe->cloneFrom(*io_info->sqe);
-        ring.submit();
-
+        task_info_ptr const io_info = submit_swap[s_cur.tid][s_cur.off];
+        submit_swap[s_cur.tid][s_cur.off] = nullptr;
         s_cur.next();
+
+        if (try_submit(io_info)) [[likely]] {
+            return true;
+        } else {
+            submit_overflow_buf.push(io_info);
+            return false;
+        }
+    }
+
+    bool try_clear_submit_overflow_buf() noexcept {
+        while (!submit_overflow_buf.empty()) {
+            task_info_ptr task = submit_overflow_buf.front();
+            // OPTIMIZE impossible for task_type::co_spawn
+            if (try_submit(task)) {
+                submit_overflow_buf.pop();
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool try_reap(task_info_ptr task) noexcept {
+        if (!r_cur.try_find_empty(reap_swap)) [[unlikely]] { return false; }
+
+        r_cur.release(reap_swap, task);
+        r_cur.next();
         return true;
     }
 
     /**
      * @brief poll the completion swap zone
-     * @return if load exists and capacity is healthy
+     * @return if reap_swap capacity might be healthy
      */
     bool poll_completion() noexcept {
-        constexpr int swap_size = sizeof(swap_zone) / sizeof(task_info *);
         // reap round
-        if (polling_cqe == nullptr) [[likely]] {
-            polling_cqe = ring.peekCQEntry();
-            if (polling_cqe == nullptr) return false;
-        }
-        int i = 0;
-        for (; i < swap_size; ++i) {
-            if (reap_swap[r_cur.slot][r_cur.tid][r_cur.off] == nullptr) break;
-            r_cur.next();
-        }
-        if (i == swap_size) return false;
-        task_info *io_info =
-            reinterpret_cast<task_info *>(polling_cqe->getData());
+        liburingcxx::CQEntry *polling_cqe = ring.peekCQEntry();
+        if (polling_cqe == nullptr) return true;
+
+        task_info_ptr io_info =
+            reinterpret_cast<task_info_ptr>(polling_cqe->getData());
         io_info->result = polling_cqe->getRes();
-
-        // release the io_info into the reap_swap
-        std::atomic_store_explicit(
-            reinterpret_cast<std::atomic<task_info *> *>(
-                &reap_swap[r_cur.slot][r_cur.tid][r_cur.off]),
-            io_info, std::memory_order_release);
-
         ring.SeenCQEntry(polling_cqe);
-        polling_cqe = nullptr;
 
-        r_cur.next();
+        if (try_reap(io_info)) [[likely]] {
+            return true;
+        } else {
+            reap_overflow_buf.push(io_info);
+            return false;
+        }
+    }
+
+    bool try_clear_reap_overflow_buf() noexcept {
+        while (!reap_overflow_buf.empty()) {
+            task_info_ptr task = reap_overflow_buf.front();
+            // OPTIMIZE impossible for task_type::co_spawn
+            if (try_reap(task)) {
+                reap_overflow_buf.pop();
+            } else {
+                return false;
+            }
+        }
         return true;
     }
 
@@ -287,57 +369,35 @@ class [[nodiscard]] io_context final {
 
     void probe() const {
         using namespace std;
+        using namespace co_context::config;
         cout << "number of logic cores: " << std::thread::hardware_concurrency()
              << endl;
         cout << "size of io_context: " << sizeof(io_context) << endl;
         cout << "size of uring: " << sizeof(uring) << endl;
-        cout << "size of single swap_zone: " << sizeof(swap_zone) << endl;
-        cout << "size of single atomic_ptr: " << sizeof(submit_swap[0][0][0])
-             << endl;
+        cout << "size of two swap_zone: " << 2 * sizeof(swap_zone) << endl;
         // cout << "swap_zone is_lock_free: "
         //      << submit_swap[0][0][0].is_lock_free() << endl;
         cout << "number of worker_threads: " << worker_threads_number << endl;
-        cout << "size of single swap_zone per thread: "
-             << swap_slots * cache_line_size << endl;
-        cout << "length of fixed swap_queue: "
-             << swap_slots * task_info_number_per_cache_line << endl;
+        cout << "swap_capacity per thread: " << swap_capacity << endl;
         cout << "size of single worker_meta: " << sizeof(worker_meta) << endl;
     }
 
     void make_thread_pool() {
-        for (int i = 0; i < worker_threads_number; ++i)
-            std::construct_at(
-                worker_threads + i, &worker_meta::run, worker + i, i, this);
-    }
-
-    void make_test_thread_pool() {
-        for (int i = 0; i < worker_threads_number; ++i)
-            std::construct_at(
-                worker_threads + i, &worker_meta::run_test_swap, worker + i, i,
-                this);
-    }
-
-    void run_test_swap() {
-        for (int64_t recv = 0; recv < test::swap_tot / worker_threads_number
-                                          * worker_threads_number;) {
-            while (submit_swap[s_cur.slot][s_cur.tid][s_cur.off] == nullptr)
-                s_cur.next();
-            submit_swap[s_cur.slot][s_cur.tid][s_cur.off] = nullptr;
-            ++recv;
-            s_cur.next();
-        }
-        printf("io_context::run(): done\n");
+        for (int i = 0; i < config::worker_threads_number; ++i)
+            worker[i].sharing.host_thread =
+                std::thread{&worker_meta::run, worker + i, i, this};
     }
 
     void co_spawn(main_task entrance) {
         const unsigned tid = detail::this_thread.tid;
-        if (tid < worker_threads_number) return worker[tid].co_spawn(entrance);
-        while (reap_swap[r_cur.slot][r_cur.tid][r_cur.off] != nullptr)
+        if (tid < config::worker_threads_number)
+            return worker[tid].co_spawn(entrance);
+        if (r_cur.try_find_empty(reap_swap)) [[likely]] {
+            r_cur.release(reap_swap, entrance.get_io_info_ptr());
             r_cur.next();
-
-        reap_swap[r_cur.slot][r_cur.tid][r_cur.off] =
-            entrance.get_io_info_ptr();
-        r_cur.next();
+        } else {
+            reap_overflow_buf.push(entrance.get_io_info_ptr());
+        }
     }
 
     [[noreturn]] void run() {
@@ -349,13 +409,17 @@ class [[nodiscard]] io_context final {
         make_thread_pool();
 
         while (true) {
-            for (uint8_t i = 0; i < config::submit_poll_rounds; ++i) {
-                // if (!poll_submission()) [[unlikely]] break;
-                poll_submission();
+            if (try_clear_submit_overflow_buf()) {
+                for (uint8_t i = 0; i < config::submit_poll_rounds; ++i) {
+                    if (!poll_submission()) break;
+                    // poll_submission();
+                }
             }
-            for (uint8_t i = 0; i < config::reap_poll_rounds; ++i) {
-                // if (!poll_completion()) break;
-                poll_completion();
+            if (try_clear_reap_overflow_buf()) {
+                for (uint8_t i = 0; i < config::reap_poll_rounds; ++i) {
+                    if (!poll_completion()) break;
+                    // poll_completion();
+                }
             }
             // std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
@@ -364,9 +428,9 @@ class [[nodiscard]] io_context final {
     inline uring &io() noexcept { return ring; }
 
     ~io_context() noexcept {
-        for (std::thread &t : worker_threads) {
+        for (int i = 0; i < config::worker_threads_number; ++i) {
+            std::thread &t = worker[i].sharing.host_thread;
             if (t.joinable()) t.join();
-            std::destroy_at(&t);
         }
     }
 
@@ -386,10 +450,51 @@ inline void co_spawn(main_task entrance) noexcept {
 namespace detail {
 
     inline void worker_meta::swap_cur::next() noexcept {
-        if (++off == task_info_number_per_cache_line) {
-            off = 0;
-            if (++slot == io_context::swap_slots) { slot = 0; }
+        off = (off + 1) % co_context::config::swap_capacity;
+    }
+
+    inline bool
+    worker_meta::swap_cur::try_find_empty(swap_zone &swap) noexcept {
+        uint16_t i = 0;
+        const uint32_t tid = this_thread.tid;
+        while (i < config::swap_capacity && swap[tid][off] != nullptr) {
+            next();
         }
+        if (i == config::swap_capacity) [[unlikely]] {
+            next();
+            return false;
+        }
+        return true;
+    }
+
+    inline bool
+    worker_meta::swap_cur::try_find_exist(swap_zone &swap) noexcept {
+        uint16_t i = 0;
+        const uint32_t tid = this_thread.tid;
+        while (i < config::swap_capacity && swap[tid][off] == nullptr) {
+            next();
+        }
+        if (i == config::swap_capacity) [[unlikely]] {
+            next();
+            return false;
+        }
+        return true;
+    }
+
+    inline void worker_meta::swap_cur::release(
+        swap_zone &swap, task_info_ptr task) const noexcept {
+        const uint32_t tid = this_thread.tid;
+        std::atomic_store_explicit(
+            reinterpret_cast<std::atomic<task_info_ptr> *>(&swap[tid][off]),
+            task, std::memory_order_release);
+    }
+
+    inline void worker_meta::swap_cur::release_relaxed(
+        swap_zone &swap, task_info_ptr task) const noexcept {
+        const uint32_t tid = this_thread.tid;
+        std::atomic_store_explicit(
+            reinterpret_cast<std::atomic<task_info_ptr> *>(&swap[tid][off]),
+            task, std::memory_order_relaxed);
     }
 
     inline void
@@ -416,52 +521,43 @@ namespace detail {
         this->submit(entrance.get_io_info_ptr());
     }
 
-    inline void worker_meta::submit(task_info *io_info) noexcept {
+    inline void worker_meta::submit(task_info_ptr io_info) noexcept {
         const unsigned tid = this_thread.tid;
         auto &ctx = *this_thread.ctx;
         auto &cur = this->submit_cur;
         // std::cerr << cur.slot << " " << tid << cur.off << std::endl;
-        while (ctx.submit_swap[cur.slot][tid][cur.off] != nullptr)
-            [[unlikely]] cur.next();
-
-        ctx.submit_swap[cur.slot][tid][cur.off] = io_info;
-        // TODO use waiting queue when overflow
-        cur.next();
+        if (cur.try_find_empty(ctx.submit_swap)) [[likely]] {
+            cur.release(ctx.submit_swap, io_info);
+            cur.next();
+        } else {
+            this->submit_overflow_buf.push(io_info);
+        }
     }
 
     inline std::coroutine_handle<> worker_meta::schedule() noexcept {
-        const unsigned tid = this_thread.tid;
+        const uint32_t tid = this_thread.tid;
         auto &ctx = *this_thread.ctx;
         auto &cur = this->reap_cur;
 
-        // int fail_cnt = 0;
-        while (ctx.reap_swap[cur.slot][tid][cur.off] == nullptr) [[likely]] {
-                cur.next();
-                // ++fail_cnt;
+        while (true) {
+            // handle overflowed submission
+            if (!this->submit_overflow_buf.empty()) {
+                auto &s_cur = this->submit_cur;
+                if (s_cur.try_find_empty(ctx.submit_swap)) {
+                    task_info_ptr task = this->submit_overflow_buf.front();
+                    this->submit_overflow_buf.pop();
+                    s_cur.release_relaxed(ctx.submit_swap, task);
+                    s_cur.next();
+                }
             }
-        // printf("%d reap fails %d\n", tid, fail_cnt);
 
-        const task_info &io_info = *ctx.reap_swap[cur.slot][tid][cur.off];
-        ctx.reap_swap[cur.slot][tid][cur.off] = nullptr;
-        cur.next();
-
-        // TODO consider tid_hint here
-        return io_info.handle;
-    }
-
-    inline void worker_meta::run_test_swap(
-        const int thread_index, io_context *const context) noexcept {
-        init(thread_index, context);
-        auto &submit_swap = context->submit_swap;
-        const int tid = detail::this_thread.tid;
-
-        for (int64_t send = 0;
-             send < test::swap_tot / io_context::worker_threads_number;) {
-            swap_cur &cur = submit_cur;
-            while (submit_swap[cur.slot][tid][cur.off] != nullptr) cur.next();
-            submit_swap[cur.slot][tid][cur.off] = (detail::task_info *)this;
-            ++send;
-            cur.next();
+            if (cur.try_find_exist(ctx.reap_swap)) [[likely]] {
+                const task_info_ptr io_info = ctx.reap_swap[tid][cur.off];
+                ctx.reap_swap[tid][cur.off] = nullptr;
+                cur.next();
+                return io_info->handle;
+            }
+            // TODO consider tid_hint here
         }
     }
 

--- a/include/co_context/config.hpp
+++ b/include/co_context/config.hpp
@@ -27,11 +27,11 @@ namespace config {
     // About io_context
     inline constexpr unsigned io_uring_flags = 0;
 
-    inline constexpr unsigned total_threads_number = 6;
+    // inline constexpr unsigned total_threads_number = 6;
 
     // inline constexpr unsigned total_threads_number = 5;
 
-    // inline constexpr unsigned total_threads_number = 4;
+    inline constexpr unsigned total_threads_number = 4;
 
     // inline constexpr unsigned total_threads_number = 3;
 
@@ -41,6 +41,14 @@ namespace config {
 
     // swap_capacity should be (N * 8)
 
+    // inline constexpr uint16_t swap_capacity = 32768;
+
+    // inline constexpr uint16_t swap_capacity = 16384;
+
+    // inline constexpr uint16_t swap_capacity = 8192;
+
+    // inline constexpr uint16_t swap_capacity = 4096;
+
     // inline constexpr uint16_t swap_capacity = 2048;
 
     // inline constexpr uint16_t swap_capacity = 512;
@@ -49,9 +57,11 @@ namespace config {
 
     // inline constexpr uint16_t swap_capacity = 128;
 
-    inline constexpr uint16_t swap_capacity = 64;
+    // inline constexpr uint16_t swap_capacity = 64;
 
     // inline constexpr uint16_t swap_capacity = 16;
+
+    inline constexpr uint16_t swap_capacity = 8;
 
     inline constexpr uint8_t submit_poll_rounds = 1;
 
@@ -60,11 +70,26 @@ namespace config {
     // net configuration
     inline constexpr bool loopback_only = true;
 
-
 } // namespace config
 
-namespace test {
-    inline constexpr int64_t swap_tot = 1'250'000'000;
-} // namespace test
+// logging config
+namespace config {
+    enum class level : int8_t {
+        v, // verbose
+        d, // debug
+        i, // info
+        w, // warning
+        e, // error
+        no_log
+    };
+
+    // inline constexpr level log_level = level::v;
+    // inline constexpr level log_level = level::d;
+    // inline constexpr level log_level = level::i;
+    // inline constexpr level log_level = level::w;
+    // inline constexpr level log_level = level::e;
+    inline constexpr level log_level = level::no_log;
+
+} // namespace config
 
 } // namespace co_context

--- a/include/co_context/config.hpp
+++ b/include/co_context/config.hpp
@@ -29,7 +29,7 @@ namespace config {
 
     // inline constexpr unsigned total_threads_number = 6;
 
-    inline constexpr unsigned total_threads_number = 4;
+    inline constexpr unsigned total_threads_number = 2;
 
     // inline constexpr unsigned total_threads_number = 2;
 
@@ -45,18 +45,18 @@ namespace config {
 
     // inline constexpr uint16_t swap_capacity = 256;
 
-    inline constexpr uint16_t swap_capacity = 128;
+    // inline constexpr uint16_t swap_capacity = 128;
 
     // inline constexpr uint16_t swap_capacity = 64;
 
-    // inline constexpr uint16_t swap_capacity = 8;
+    inline constexpr uint16_t swap_capacity = 8;
 
-    inline constexpr uint8_t submit_poll_rounds = 4;
+    inline constexpr uint8_t submit_poll_rounds = 1;
 
-    inline constexpr uint8_t reap_poll_rounds = 4;
+    inline constexpr uint8_t reap_poll_rounds = 1;
 
     // net configuration
-    inline constexpr bool loopback_only = true;
+    inline constexpr bool loopback_only = false;
 
 
 } // namespace config

--- a/include/co_context/config.hpp
+++ b/include/co_context/config.hpp
@@ -37,15 +37,17 @@ namespace config {
 
     inline constexpr bool low_latency_mode = true;
 
+    // swap_capacity should be (N * 8)
+
     // inline constexpr uint16_t swap_capacity = 2048;
 
     // inline constexpr uint16_t swap_capacity = 512;
 
     // inline constexpr uint16_t swap_capacity = 256;
 
-    // inline constexpr uint16_t swap_capacity = 128;
+    inline constexpr uint16_t swap_capacity = 128;
 
-    inline constexpr uint16_t swap_capacity = 64;
+    // inline constexpr uint16_t swap_capacity = 64;
 
     // inline constexpr uint16_t swap_capacity = 8;
 

--- a/include/co_context/config.hpp
+++ b/include/co_context/config.hpp
@@ -8,7 +8,7 @@ namespace co_context {
 
 namespace config {
 
-    inline constexpr bool use_hyper_threading = true;
+    inline constexpr bool using_hyper_threading = true;
 // #define USE_CPU_AFFINITY
 #ifdef USE_CPU_AFFINITY
     inline constexpr bool use_CPU_affinity = true;
@@ -27,11 +27,13 @@ namespace config {
     // About io_context
     inline constexpr unsigned io_uring_flags = 0;
 
-    // inline constexpr unsigned total_threads_number = 6;
+    inline constexpr unsigned total_threads_number = 6;
 
-    inline constexpr unsigned total_threads_number = 2;
+    // inline constexpr unsigned total_threads_number = 5;
 
-    // inline constexpr unsigned total_threads_number = 2;
+    // inline constexpr unsigned total_threads_number = 4;
+
+    // inline constexpr unsigned total_threads_number = 3;
 
     // inline constexpr unsigned total_threads_number = 2;
 
@@ -47,16 +49,16 @@ namespace config {
 
     // inline constexpr uint16_t swap_capacity = 128;
 
-    // inline constexpr uint16_t swap_capacity = 64;
+    inline constexpr uint16_t swap_capacity = 64;
 
-    inline constexpr uint16_t swap_capacity = 8;
+    // inline constexpr uint16_t swap_capacity = 16;
 
     inline constexpr uint8_t submit_poll_rounds = 1;
 
     inline constexpr uint8_t reap_poll_rounds = 1;
 
     // net configuration
-    inline constexpr bool loopback_only = false;
+    inline constexpr bool loopback_only = true;
 
 
 } // namespace config

--- a/include/co_context/lazy_io.hpp
+++ b/include/co_context/lazy_io.hpp
@@ -107,6 +107,19 @@ inline namespace lazy {
         return awaiter;
     }
 
+    lazy_awaiter fsync(int fd, uint32_t fsync_flags) noexcept {
+        lazy_awaiter awaiter;
+        awaiter.sqe.prepareFsync(fd, fsync_flags);
+        return awaiter;
+    }
+
+    lazy_awaiter
+    sync_file_range(int fd, uint32_t len, uint64_t offset, int flags) noexcept {
+        lazy_awaiter awaiter;
+        awaiter.sqe.prepareSyncFileRange(fd, len, offset, flags);
+        return awaiter;
+    }
+
     lazy_awaiter_yield yield() noexcept { return {}; }
 
 } // namespace lazy

--- a/include/co_context/log/log.hpp
+++ b/include/co_context/log/log.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "co_context/config.hpp"
+#include <cstdio>
+
+namespace co_context {
+
+namespace detail {
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+
+    template<typename... T>
+    void log(const char *__restrict__ fmt, const T &...args) {
+        printf(fmt, args...);
+    }
+
+    template<typename... T>
+    void err(const char *__restrict__ fmt, const T &...args) {
+        fprintf(stderr, fmt, args...);
+    }
+
+#pragma GCC diagnostic pop
+
+} // namespace detail
+
+namespace log {
+    template<typename... T>
+    void v(const char *__restrict__ fmt, const T &...args) {
+        if constexpr (config::log_level <= config::level::v)
+            detail::log(fmt, args...);
+    }
+    template<typename... T>
+    void i(const char *__restrict__ fmt, const T &...args) {
+        if constexpr (config::log_level <= config::level::i)
+            detail::log(fmt, args...);
+    }
+    template<typename... T>
+    void d(const char *__restrict__ fmt, const T &...args) {
+        if constexpr (config::log_level <= config::level::d)
+            detail::log(fmt, args...);
+    }
+    template<typename... T>
+    void w(const char *__restrict__ fmt, const T &...args) {
+        if constexpr (config::log_level <= config::level::w)
+            detail::log(fmt, args...);
+    }
+    template<typename... T>
+    void e(const char *__restrict__ fmt, const T &...args) {
+        if constexpr (config::log_level <= config::level::e)
+            detail::err(fmt, args...);
+    }
+} // namespace log
+
+} // namespace co_context

--- a/include/co_context/main_task.hpp
+++ b/include/co_context/main_task.hpp
@@ -7,6 +7,7 @@
 #include "task_info.hpp"
 #include <memory>
 #include <cassert>
+#include "co_context/log/log.hpp"
 
 namespace co_context {
 
@@ -28,6 +29,7 @@ class main_task {
             auto handle =
                 std::coroutine_handle<promise_type>::from_promise(*this);
             io_info.handle = handle;
+            log::v("main_task generated\n");
             return main_task{handle};
         }
 

--- a/include/co_context/task_info.hpp
+++ b/include/co_context/task_info.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "../uring.hpp"
 #include <coroutine>
+#include "co_context/log/log.hpp"
 
 namespace co_context {
 namespace detail {
@@ -14,11 +15,13 @@ namespace detail {
             CQEntry *cqe;
             int32_t result;
         };
-        enum class task_type { sqe, cqe, result, co_spawn, nop } type;
         std::coroutine_handle<> handle;
         int tid_hint;
+        enum class task_type { sqe, cqe, result, co_spawn, nop } type;
 
-        constexpr task_info(task_type type) noexcept : type(type) {}
+        constexpr task_info(task_type type) noexcept : type(type) {
+            log::v("task_info generated\n");
+        }
 
         static task_info nop() noexcept {
             task_info ret{task_type::nop};

--- a/include/co_context/task_info.hpp
+++ b/include/co_context/task_info.hpp
@@ -44,6 +44,8 @@ namespace detail {
                 } */
     };
 
+    using task_info_ptr = task_info *;
+
 } // namespace detail
 
 } // namespace co_context

--- a/include/uring.hpp
+++ b/include/uring.hpp
@@ -227,6 +227,19 @@ class SQEntry : private io_uring_sqe {
         return prepareRW(IORING_OP_SHUTDOWN, fd, nullptr, (uint32_t)how, 0);
     }
 
+    inline SQEntry &prepareFsync(int fd, uint32_t fsync_flags) noexcept {
+        prepareRW(IORING_OP_SYNC_FILE_RANGE, fd, nullptr, 0, 0);
+        this->fsync_flags = fsync_flags;
+        return *this;
+    }
+
+    inline SQEntry &prepareSyncFileRange(
+        int fd, uint32_t len, uint64_t offset, int flags) noexcept {
+        prepareRW(IORING_OP_SYNC_FILE_RANGE, fd, nullptr, len, offset);
+        this->sync_range_flags = (uint32_t)flags;
+        return *this;
+    }
+
     /* TODO: more prepare: splice, tee, cancel, epoll_ctl
      * ......
      */

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -19,10 +19,6 @@ int main(int argc, char *argv[]) {
 
     // io_context.probe();
 
-    // io_context.make_test_thread_pool();
-
-    // io_context.run_test_swap();
-
     int output_fd = ::open("output", O_WRONLY | O_TRUNC);
 
     io_context.co_spawn([&]() -> main_task {


### PR DESCRIPTION
Add a thread-local buffer(std::queue) to handle the overflow task, including submission and completion.
Add a console logger to watch the internel state of co_context.

Known problem: For each thread, during a coro, the first time creating another coro would cost a lot of time, especially when cpu_affinity is enabled. It seems to be relative to operator new() and the OS scheduling.

现在，在提交/收割队列中溢出的任务将会被临时存储在线程独享的队列中（由 std::queue 实现）。
添加了新的分级 logger，类似 Android 的 log.d()，便于我们观察 co_context 内部每个线程的运行状态。

已知问题：每个线程第一次在协程内创建新的协程时，可能会有短暂暂停，在启用 cpu_affinity 时尤其明显，这可能与 operator new() 或者操作系统的调度有关。