### PR TITLE
feat: add generator.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,7 +86,8 @@
         "unordered_set": "cpp",
         "fstream": "cpp",
         "future": "cpp",
-        "source_location": "cpp"
+        "source_location": "cpp",
+        "ranges": "cpp"
     },
     "cmake.buildTask": true
 }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A coroutine framework aimed at high-concurrency io with reasonable latency, base
 
 ```cpp
     using namespace co_context;
-    io_context context{32};
+    io_context context{32768};
 ```
 
 定义一个 socket 监听任务：
@@ -63,7 +63,7 @@ int main(int argc, const char *argv[]) {
         return 0;
     }
 
-    io_context context{32};
+    io_context context{32768};
 
     int port = atoi(argv[2]);
     if (strcmp(argv[1], "-l") == 0) {

--- a/example/cv.cpp
+++ b/example/cv.cpp
@@ -62,7 +62,7 @@ task<> main_thread() {
 }
 
 int main() {
-    io_context ctx{32};
+    io_context ctx{32768};
     ctx.co_spawn(worker_thread());
     ctx.co_spawn(main_thread());
 

--- a/example/cv_all.cpp
+++ b/example/cv_all.cpp
@@ -45,7 +45,7 @@ task<> signals() {
 }
 
 int main() {
-    io_context ctx{32};
+    io_context ctx{32768};
     ctx.co_spawn(waits());
     ctx.co_spawn(waits());
     ctx.co_spawn(waits());

--- a/example/fingerprint.cpp
+++ b/example/fingerprint.cpp
@@ -81,7 +81,7 @@ int main(int argc, char *argv[]) {
     }
 
     const int port = atoi(argv[1]);
-    io_context context{256};
+    io_context context{32768};
     context.co_spawn(server(port, argv[2]));
 
     context.run();

--- a/example/fingerprint_blocking.cpp
+++ b/example/fingerprint_blocking.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
     }
 
     const int port = atoi(argv[1]);
-    io_context context{256};
+    io_context context{32768};
     context.co_spawn(server(port, argv[2]));
 
     context.run();

--- a/example/fingerprint_client.cpp
+++ b/example/fingerprint_client.cpp
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
         return 0;
     }
 
-    io_context context{128};
+    io_context context{32768};
 
     const int port = atoi(argv[2]);
     concurrency = atoi(argv[3]);

--- a/example/netcat.cpp
+++ b/example/netcat.cpp
@@ -62,7 +62,7 @@ int main(int argc, const char *argv[]) {
     }
 
     using namespace co_context;
-    io_context context{16};
+    io_context context{32768};
 
     int port = atoi(argv[2]);
     if (strcmp(argv[1], "-l") == 0) {

--- a/example/netcat_eager.cpp
+++ b/example/netcat_eager.cpp
@@ -87,7 +87,7 @@ int main(int argc, const char *argv[]) {
     }
 
     using namespace co_context;
-    io_context context{4};
+    io_context context{32768};
 
     int port = atoi(argv[2]);
     if (strcmp(argv[1], "-l") == 0) {

--- a/example/netcat_eager_detach.cpp
+++ b/example/netcat_eager_detach.cpp
@@ -102,7 +102,7 @@ int main(int argc, const char *argv[]) {
     }
 
     using namespace co_context;
-    io_context context{4};
+    io_context context{32768};
 
     int port = atoi(argv[2]);
     if (strcmp(argv[1], "-l") == 0) {

--- a/example/netcat_timeout.cpp
+++ b/example/netcat_timeout.cpp
@@ -76,7 +76,7 @@ int main(int argc, const char *argv[]) {
         return 0;
     }
 
-    io_context context{32};
+    io_context context{32768};
 
     int port = atoi(argv[2]);
     if (strcmp(argv[1], "-l") == 0) {

--- a/example/sem.cpp
+++ b/example/sem.cpp
@@ -91,7 +91,7 @@ task<> workerThread(unsigned id) {
 }
 
 int main() {
-    io_context ctx{128};
+    io_context ctx{32768};
 
     for (auto id{0U}; id != max_threads; ++id) {
         ctx.co_spawn(workerThread(id));

--- a/example/timeout.cpp
+++ b/example/timeout.cpp
@@ -19,7 +19,7 @@ task<> my_clock() {
 }
 
 int main() {
-    io_context ctx{32};
+    io_context ctx{32768};
     // ctx.co_spawn(delay_output());
     ctx.co_spawn(my_clock());
     ctx.run();

--- a/include/co_context/config.hpp
+++ b/include/co_context/config.hpp
@@ -10,8 +10,8 @@ namespace co_context {
 namespace config {
 
     // ======================== io_uring configuration ========================
-    // inline constexpr unsigned io_uring_flags = 0;
-    inline constexpr unsigned io_uring_flags = IORING_SETUP_SQPOLL;
+    inline constexpr unsigned io_uring_flags = 0;
+    // inline constexpr unsigned io_uring_flags = IORING_SETUP_SQPOLL;
     // ========================================================================
 
     // ========================== CPU configuration ===========================
@@ -136,8 +136,8 @@ namespace config {
     // inline constexpr level log_level = level::debug;
     // inline constexpr level log_level = level::info;
     // inline constexpr level log_level = level::warning;
-    // inline constexpr level log_level = level::error;
-    inline constexpr level log_level = level::no_log;
+    inline constexpr level log_level = level::error;
+    // inline constexpr level log_level = level::no_log;
 
 } // namespace config
 

--- a/include/co_context/generator.hpp
+++ b/include/co_context/generator.hpp
@@ -1,0 +1,585 @@
+////////////////////////////////////////////////////////////////
+// Reference implementation of std::generator proposal P2502R2
+// Authors: Casey Carter, Lewis Baker, Corentin Jabot.
+// https://godbolt.org/z/5hcaPcfvP
+//
+
+#include <algorithm>
+#include <cassert>
+#include <coroutine>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <new>
+#include <ranges>
+#include <type_traits>
+#include <utility>
+
+#ifdef _MSC_VER
+#define EMPTY_BASES __declspec(empty_bases)
+#ifdef __clang__
+#define NO_UNIQUE_ADDRESS
+#else
+#define NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#endif
+#else
+#define EMPTY_BASES
+#define NO_UNIQUE_ADDRESS [[no_unique_address]]
+#endif
+
+// namespace std {
+namespace co_context {
+
+struct alignas(__STDCPP_DEFAULT_NEW_ALIGNMENT__) _Aligned_block {
+    unsigned char _Pad[__STDCPP_DEFAULT_NEW_ALIGNMENT__];
+};
+
+template<class _Alloc>
+using _Rebind = typename std::allocator_traits<_Alloc>::template rebind_alloc<
+    _Aligned_block>;
+
+template<class _Alloc>
+concept _Has_real_pointers = std::same_as<_Alloc, void> || std::is_pointer_v<
+    typename std::allocator_traits<_Alloc>::pointer>;
+
+template<class _Allocator = void>
+class _Promise_allocator { // statically specified allocator type
+  private:
+    using _Alloc = _Rebind<_Allocator>;
+
+    static void *_Allocate(_Alloc _Al, const size_t _Size) {
+        if constexpr (std::default_initializable<_Alloc> && std::allocator_traits<_Alloc>::is_always_equal::value) {
+            // do not store stateless allocator
+            const size_t _Count =
+                (_Size + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
+            return _Al.allocate(_Count);
+        } else {
+            // store stateful allocator
+            static constexpr size_t _Align =
+                (::std::max)(alignof(_Alloc), sizeof(_Aligned_block));
+            const size_t _Count =
+                (_Size + sizeof(_Alloc) + _Align - 1) / sizeof(_Aligned_block);
+            void *const _Ptr = _Al.allocate(_Count);
+            const auto _Al_address = (reinterpret_cast<uintptr_t>(_Ptr) + _Size
+                                      + alignof(_Alloc) - 1)
+                                     & ~(alignof(_Alloc) - 1);
+            ::new (reinterpret_cast<void *>(_Al_address))
+                _Alloc(::std::move(_Al));
+            return _Ptr;
+        }
+    }
+
+  public:
+    static void *operator new(const size_t _Size
+    ) requires std::default_initializable<_Alloc> {
+        return _Allocate(_Alloc{}, _Size);
+    }
+
+    template<class _Alloc2, class... _Args>
+        requires std::convertible_to<const _Alloc2 &, _Allocator>
+
+    static void *operator new(
+        const size_t _Size,
+        std::allocator_arg_t,
+        const _Alloc2 &_Al,
+        const _Args &...
+    ) {
+        return _Allocate(
+            static_cast<_Alloc>(static_cast<_Allocator>(_Al)), _Size
+        );
+    }
+
+    template<class _This, class _Alloc2, class... _Args>
+        requires std::convertible_to<const _Alloc2 &, _Allocator>
+
+    static void *operator new(
+        const size_t _Size,
+        const _This &,
+        std::allocator_arg_t,
+        const _Alloc2 &_Al,
+        const _Args &...
+    ) {
+        return _Allocate(
+            static_cast<_Alloc>(static_cast<_Allocator>(_Al)), _Size
+        );
+    }
+
+    static void operator delete(void *const _Ptr, const size_t _Size) noexcept {
+        if constexpr (std::default_initializable<_Alloc> && std::allocator_traits<_Alloc>::is_always_equal::value) {
+            // make stateless allocator
+            _Alloc _Al{};
+            const size_t _Count =
+                (_Size + sizeof(_Aligned_block) - 1) / sizeof(_Aligned_block);
+            _Al.deallocate(static_cast<_Aligned_block *>(_Ptr), _Count);
+        } else {
+            // retrieve stateful allocator
+            const auto _Al_address = (reinterpret_cast<uintptr_t>(_Ptr) + _Size
+                                      + alignof(_Alloc) - 1)
+                                     & ~(alignof(_Alloc) - 1);
+            auto &_Stored_al = *reinterpret_cast<_Alloc *>(_Al_address);
+            _Alloc _Al{::std::move(_Stored_al)};
+            _Stored_al.~_Alloc();
+
+            static constexpr size_t _Align =
+                (::std::max)(alignof(_Alloc), sizeof(_Aligned_block));
+            const size_t _Count =
+                (_Size + sizeof(_Alloc) + _Align - 1) / sizeof(_Aligned_block);
+            _Al.deallocate(static_cast<_Aligned_block *>(_Ptr), _Count);
+        }
+    }
+};
+
+template<>
+class _Promise_allocator<void> { // type-erased allocator
+  private:
+    using _Dealloc_fn = void (*)(void *, size_t);
+
+    template<class _ProtoAlloc>
+    static void *_Allocate(const _ProtoAlloc &_Proto, size_t _Size) {
+        using _Alloc = _Rebind<_ProtoAlloc>;
+        auto _Al = static_cast<_Alloc>(_Proto);
+
+        if constexpr (std::default_initializable<_Alloc> && std::allocator_traits<_Alloc>::is_always_equal::value) {
+            // don't store stateless allocator
+            const _Dealloc_fn _Dealloc = [](void *const _Ptr,
+                                            const size_t _Size) {
+                _Alloc _Al{};
+                const size_t _Count =
+                    (_Size + sizeof(_Dealloc_fn) + sizeof(_Aligned_block) - 1)
+                    / sizeof(_Aligned_block);
+                _Al.deallocate(static_cast<_Aligned_block *>(_Ptr), _Count);
+            };
+
+            const size_t _Count =
+                (_Size + sizeof(_Dealloc_fn) + sizeof(_Aligned_block) - 1)
+                / sizeof(_Aligned_block);
+            void *const _Ptr = _Al.allocate(_Count);
+            ::memcpy(
+                static_cast<char *>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc)
+            );
+            return _Ptr;
+        } else {
+            // store stateful allocator
+            static constexpr size_t _Align =
+                (::std::max)(alignof(_Alloc), sizeof(_Aligned_block));
+
+            const _Dealloc_fn _Dealloc = [](void *const _Ptr, size_t _Size) {
+                _Size += sizeof(_Dealloc_fn);
+                const auto _Al_address = (reinterpret_cast<uintptr_t>(_Ptr)
+                                          + _Size + alignof(_Alloc) - 1)
+                                         & ~(alignof(_Alloc) - 1);
+                auto &_Stored_al =
+                    *reinterpret_cast<const _Alloc *>(_Al_address);
+                _Alloc _Al{::std::move(_Stored_al)};
+                _Stored_al.~_Alloc();
+
+                const size_t _Count =
+                    (_Size + sizeof(_Al) + _Align - 1) / sizeof(_Aligned_block);
+                _Al.deallocate(static_cast<_Aligned_block *>(_Ptr), _Count);
+            };
+
+            const size_t _Count =
+                (_Size + sizeof(_Dealloc_fn) + sizeof(_Al) + _Align - 1)
+                / sizeof(_Aligned_block);
+            void *const _Ptr = _Al.allocate(_Count);
+            ::memcpy(
+                static_cast<char *>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc)
+            );
+            _Size += sizeof(_Dealloc_fn);
+            const auto _Al_address = (reinterpret_cast<uintptr_t>(_Ptr) + _Size
+                                      + alignof(_Alloc) - 1)
+                                     & ~(alignof(_Alloc) - 1);
+            ::new (reinterpret_cast<void *>(_Al_address))
+                _Alloc{::std::move(_Al)};
+            return _Ptr;
+        }
+    }
+
+  public:
+    static void *operator new(const size_t _Size) { // default: new/delete
+        void *const _Ptr = ::operator new[](_Size + sizeof(_Dealloc_fn));
+        const _Dealloc_fn _Dealloc = [](void *const _Ptr, const size_t _Size) {
+            ::operator delete[](_Ptr, _Size + sizeof(_Dealloc_fn));
+        };
+        ::memcpy(
+            static_cast<char *>(_Ptr) + _Size, &_Dealloc, sizeof(_Dealloc_fn)
+        );
+        return _Ptr;
+    }
+
+    template<class _Alloc, class... _Args>
+    static void *operator new(
+        const size_t _Size,
+        std::allocator_arg_t,
+        const _Alloc &_Al,
+        const _Args &...
+    ) {
+        static_assert(
+            _Has_real_pointers<_Alloc>,
+            "coroutine allocators must use true pointers"
+        );
+        return _Allocate(_Al, _Size);
+    }
+
+    template<class _This, class _Alloc, class... _Args>
+    static void *operator new(
+        const size_t _Size,
+        const _This &,
+        std::allocator_arg_t,
+        const _Alloc &_Al,
+        const _Args &...
+    ) {
+        static_assert(
+            _Has_real_pointers<_Alloc>,
+            "coroutine allocators must use true pointers"
+        );
+        return _Allocate(_Al, _Size);
+    }
+
+    static void operator delete(void *const _Ptr, const size_t _Size) noexcept {
+        _Dealloc_fn _Dealloc;
+        ::memcpy(
+            &_Dealloc, static_cast<const char *>(_Ptr) + _Size,
+            sizeof(_Dealloc_fn)
+        );
+        _Dealloc(_Ptr, _Size);
+    }
+};
+
+namespace ranges {
+    template<std::ranges::range _Rng, class _Alloc = std::allocator<std::byte>>
+    struct elements_of {
+        NO_UNIQUE_ADDRESS _Rng range;
+        NO_UNIQUE_ADDRESS _Alloc allocator{};
+    };
+
+    template<class _Rng, class _Alloc = std::allocator<std::byte>>
+    elements_of(_Rng &&, _Alloc = {}) -> elements_of<_Rng &&, _Alloc>;
+} // namespace ranges
+
+template<class _Rty, class _Vty = void, class _Alloc = void>
+class generator;
+
+template<class _Rty, class _Vty>
+using _Gen_value_t =
+    std::conditional_t<std::is_void_v<_Vty>, std::remove_cvref_t<_Rty>, _Vty>;
+template<class _Rty, class _Vty>
+using _Gen_reference_t =
+    std::conditional_t<std::is_void_v<_Vty>, _Rty &&, _Rty>;
+template<class _Ref>
+using _Gen_yield_t =
+    std::conditional_t<std::is_reference_v<_Ref>, _Ref, const _Ref &>;
+
+template<class _Yielded>
+class _Gen_promise_base {
+  public:
+    static_assert(std::is_reference_v<_Yielded>);
+
+    /* [[nodiscard]] */ std::suspend_always initial_suspend() noexcept {
+        return {};
+    }
+
+    [[nodiscard]] auto final_suspend() noexcept { return _Final_awaiter{}; }
+
+    [[nodiscard]] std::suspend_always yield_value(_Yielded _Val) noexcept {
+        _Ptr = ::std::addressof(_Val);
+        return {};
+    }
+
+    // clang-format off
+        [[nodiscard]] auto yield_value(const std::remove_reference_t<_Yielded>& _Val)
+            noexcept(std::is_nothrow_constructible_v<std::remove_cvref_t<_Yielded>, const std::remove_reference_t<_Yielded>&>)
+            requires (std::is_rvalue_reference_v<_Yielded> &&
+                std::constructible_from<std::remove_cvref_t<_Yielded>, const std::remove_reference_t<_Yielded>&>) {
+        // clang-format on
+        return _Element_awaiter{_Val};
+    }
+
+    // clang-format off
+        template <class _Rty, class _Vty, class _Alloc, class _Unused>
+            requires std::same_as<_Gen_yield_t<_Gen_reference_t<_Rty, _Vty>>, _Yielded>
+        [[nodiscard]] auto yield_value(
+            ::co_context::ranges::elements_of<generator<_Rty, _Vty, _Alloc>&&, _Unused> _Elem) noexcept {
+        // clang-format on
+        return _Nested_awaitable<_Rty, _Vty, _Alloc>{std::move(_Elem.range)};
+    }
+
+    // clang-format off
+        template <::std::ranges::input_range _Rng, class _Alloc>
+            requires std::convertible_to<::std::ranges::range_reference_t<_Rng>, _Yielded>
+        [[nodiscard]] auto yield_value(::co_context::ranges::elements_of<_Rng, _Alloc> _Elem) noexcept {
+        // clang-format on
+        using _Vty = ::std::ranges::range_value_t<_Rng>;
+        return _Nested_awaitable<_Yielded, _Vty, _Alloc>{
+            [](std::allocator_arg_t, _Alloc,
+               ::std::ranges::iterator_t<_Rng> _It,
+               const ::std::ranges::sentinel_t<_Rng> _Se
+            ) -> generator<_Yielded, _Vty, _Alloc> {
+                for (; _It != _Se; ++_It) {
+                    co_yield static_cast<_Yielded>(*_It);
+                }
+            }(std::allocator_arg, _Elem.allocator,
+              ::std::ranges::begin(_Elem.range),
+              ::std::ranges::end(_Elem.range))};
+    }
+
+    void await_transform() = delete;
+
+    void return_void() noexcept {}
+
+    void unhandled_exception() {
+        if (_Info) {
+            _Info->_Except = ::std::current_exception();
+        } else {
+            throw;
+        }
+    }
+
+  private:
+    struct _Element_awaiter {
+        std::remove_cvref_t<_Yielded> _Val;
+
+        [[nodiscard]] constexpr bool await_ready() const noexcept {
+            return false;
+        }
+
+        template<class _Promise>
+        constexpr void await_suspend(std::coroutine_handle<_Promise> _Handle
+        ) noexcept {
+#ifdef __cpp_lib_is_pointer_interconvertible
+            static_assert(std::is_pointer_interconvertible_base_of_v<
+                          _Gen_promise_base, _Promise>);
+#endif // __cpp_lib_is_pointer_interconvertible
+
+            _Gen_promise_base &_Current = _Handle.promise();
+            _Current._Ptr = ::std::addressof(_Val);
+        }
+
+        constexpr void await_resume() const noexcept {
+        }
+    };
+
+    struct _Nest_info {
+        std::exception_ptr _Except;
+        std::coroutine_handle<_Gen_promise_base> _Parent;
+        std::coroutine_handle<_Gen_promise_base> _Root;
+    };
+
+    struct _Final_awaiter {
+        [[nodiscard]] bool await_ready() noexcept { return false; }
+
+        template<class _Promise>
+        [[nodiscard]] std::coroutine_handle<>
+        await_suspend(std::coroutine_handle<_Promise> _Handle) noexcept {
+#ifdef __cpp_lib_is_pointer_interconvertible
+            static_assert(std::is_pointer_interconvertible_base_of_v<
+                          _Gen_promise_base, _Promise>);
+#endif // __cpp_lib_is_pointer_interconvertible
+
+            _Gen_promise_base &_Current = _Handle.promise();
+            if (!_Current._Info) { return ::std::noop_coroutine(); }
+
+            std::coroutine_handle<_Gen_promise_base> _Cont =
+                _Current._Info->_Parent;
+            _Current._Info->_Root.promise()._Top = _Cont;
+            _Current._Info = nullptr;
+            return _Cont;
+        }
+
+        void await_resume() noexcept {
+        }
+    };
+
+    template<class _Rty, class _Vty, class _Alloc>
+    struct _Nested_awaitable {
+        static_assert(std::same_as<
+                      _Gen_yield_t<_Gen_reference_t<_Rty, _Vty>>,
+                      _Yielded>);
+
+        _Nest_info _Nested;
+        generator<_Rty, _Vty, _Alloc> _Gen;
+
+        explicit _Nested_awaitable(generator<_Rty, _Vty, _Alloc> &&_Gen_
+        ) noexcept
+            : _Gen(::std::move(_Gen_)) {}
+
+        [[nodiscard]] bool await_ready() noexcept { return !_Gen._Coro; }
+
+        template<class _Promise>
+        [[nodiscard]] std::coroutine_handle<_Gen_promise_base>
+        await_suspend(std::coroutine_handle<_Promise> _Current) noexcept {
+#ifdef __cpp_lib_is_pointer_interconvertible
+            static_assert(std::is_pointer_interconvertible_base_of_v<
+                          _Gen_promise_base, _Promise>);
+#endif // __cpp_lib_is_pointer_interconvertible
+            auto _Target =
+                std::coroutine_handle<_Gen_promise_base>::from_address(
+                    _Gen._Coro.address()
+                );
+            _Nested._Parent =
+                std::coroutine_handle<_Gen_promise_base>::from_address(
+                    _Current.address()
+                );
+            _Gen_promise_base &_Parent_promise = _Nested._Parent.promise();
+            if (_Parent_promise._Info) {
+                _Nested._Root = _Parent_promise._Info->_Root;
+            } else {
+                _Nested._Root = _Nested._Parent;
+            }
+            _Nested._Root.promise()._Top = _Target;
+            _Target.promise()._Info = ::std::addressof(_Nested);
+            return _Target;
+        }
+
+        void await_resume() {
+            if (_Nested._Except) {
+                ::std::rethrow_exception(::std::move(_Nested._Except));
+            }
+        }
+    };
+
+    template<class, class>
+    friend class _Gen_iter;
+
+    // _Top and _Info are mutually exclusive, and could potentially be merged.
+    std::coroutine_handle<_Gen_promise_base> _Top =
+        std::coroutine_handle<_Gen_promise_base>::from_promise(*this);
+    std::add_pointer_t<_Yielded> _Ptr = nullptr;
+    _Nest_info *_Info = nullptr;
+};
+
+struct _Gen_secret_tag {};
+
+template<class _Value, class _Ref>
+class _Gen_iter {
+  public:
+    using value_type = _Value;
+    using difference_type = ptrdiff_t;
+
+    _Gen_iter(_Gen_iter &&_That) noexcept
+        : _Coro{::std::exchange(_That._Coro, {})} {}
+
+    _Gen_iter &operator=(_Gen_iter &&_That) noexcept {
+        _Coro = ::std::exchange(_That._Coro, {});
+        return *this;
+    }
+
+    [[nodiscard]] _Ref operator*() const noexcept {
+        assert(!_Coro.done() && "Can't dereference generator end iterator");
+        return static_cast<_Ref>(*_Coro.promise()._Top.promise()._Ptr);
+    }
+
+    _Gen_iter &operator++() {
+        assert(!_Coro.done() && "Can't increment generator end iterator");
+        _Coro.promise()._Top.resume();
+        return *this;
+    }
+
+    void operator++(int) { ++*this; }
+
+    [[nodiscard]] bool operator==(std::default_sentinel_t) const noexcept {
+        return _Coro.done();
+    }
+
+  private:
+    template<class, class, class>
+    friend class generator;
+
+    explicit _Gen_iter(
+        _Gen_secret_tag,
+        std::coroutine_handle<_Gen_promise_base<_Gen_yield_t<_Ref>>> _Coro_
+    ) noexcept
+        : _Coro{_Coro_} {}
+
+    std::coroutine_handle<_Gen_promise_base<_Gen_yield_t<_Ref>>> _Coro;
+};
+
+template<class _Rty, class _Vty, class _Alloc>
+class generator
+    : public std::ranges::view_interface<generator<_Rty, _Vty, _Alloc>> {
+  private:
+    using _Value = _Gen_value_t<_Rty, _Vty>;
+    static_assert(
+        std::same_as<
+            std::remove_cvref_t<_Value>,
+            _Value> && std::is_object_v<_Value>,
+        "generator's value type must be a cv-unqualified object type"
+    );
+
+    // clang-format off
+    using _Ref = _Gen_reference_t<_Rty, _Vty>;
+    static_assert(std::is_reference_v<_Ref>
+        || (std::is_object_v<_Ref> && std::same_as<std::remove_cv_t<_Ref>, _Ref> && std::copy_constructible<_Ref>),
+        "generator's second argument must be a reference type or a cv-unqualified "
+        "copy-constructible object type");
+
+    using _RRef = std::conditional_t<std::is_lvalue_reference_v<_Ref>, std::remove_reference_t<_Ref>&&, _Ref>;
+
+    static_assert(std::common_reference_with<_Ref&&, _Value&> && std::common_reference_with<_Ref&&, _RRef&&>
+        && std::common_reference_with<_RRef&&, const _Value&>,
+        "an iterator with the selected value and reference types cannot model indirectly_readable");
+    // clang-format on
+
+    static_assert(
+        _Has_real_pointers<_Alloc>,
+        "generator allocators must use true pointers"
+    );
+
+    friend _Gen_promise_base<_Gen_yield_t<_Ref>>;
+
+  public:
+    struct EMPTY_BASES promise_type
+        : _Promise_allocator<_Alloc>
+        , _Gen_promise_base<_Gen_yield_t<_Ref>> {
+        [[nodiscard]] generator get_return_object() noexcept {
+            return generator{
+                _Gen_secret_tag{},
+                std::coroutine_handle<promise_type>::from_promise(*this)};
+        }
+    };
+
+    static_assert(std::is_standard_layout_v<promise_type>);
+#ifdef __cpp_lib_is_pointer_interconvertible
+    static_assert(std::is_pointer_interconvertible_base_of_v<
+                  _Gen_promise_base<_Gen_yield_t<_Ref>>,
+                  promise_type>);
+#endif // __cpp_lib_is_pointer_interconvertible
+
+    generator(generator &&_That) noexcept
+        : _Coro(::std::exchange(_That._Coro, {})) {
+    }
+
+    ~generator() {
+        if (_Coro) { _Coro.destroy(); }
+    }
+
+    generator &operator=(generator _That) noexcept {
+        ::std::swap(_Coro, _That._Coro);
+        return *this;
+    }
+
+    [[nodiscard]] _Gen_iter<_Value, _Ref> begin() {
+        // Pre: _Coro is suspended at its initial suspend point
+        assert(_Coro && "Can't call begin on moved-from generator");
+        _Coro.resume();
+        return _Gen_iter<_Value, _Ref>{
+            _Gen_secret_tag{},
+            std::coroutine_handle<_Gen_promise_base<_Gen_yield_t<_Ref>>>::
+                from_address(_Coro.address())};
+    }
+
+    [[nodiscard]] std::default_sentinel_t end() const noexcept {
+        return std::default_sentinel;
+    }
+
+  private:
+    std::coroutine_handle<promise_type> _Coro = nullptr;
+
+    explicit generator(
+        _Gen_secret_tag, std::coroutine_handle<promise_type> _Coro_
+    ) noexcept
+        : _Coro(_Coro_) {
+    }
+};
+} // namespace co_context

--- a/test/ctx_swtch.cpp
+++ b/test/ctx_swtch.cpp
@@ -25,7 +25,7 @@ task<> run() {
 }
 
 int main() {
-    io_context ctx{128};
+    io_context ctx{32768};
 
     for (int i = 0; i < config::swap_capacity / 2; ++i) ctx.co_spawn(run());
 

--- a/test/generator_test.cpp
+++ b/test/generator_test.cpp
@@ -1,0 +1,299 @@
+#include "co_context/generator.hpp"
+
+/////////////////////////////////////////////////////////////////////////////
+// Examples start here
+
+#include <array>
+#include <cinttypes>
+#include <cstdio>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace {
+///////////////////////
+// Simple non-nested serial generator
+
+co_context::generator<uint64_t> fib(int max) {
+    auto a = 0, b = 1;
+    for (auto n = 0; n < max; n++) {
+        co_yield std::exchange(a, std::exchange(b, a + b));
+    }
+} // namespace co_context::generator<uint64_t>fib(intmax)
+
+co_context::generator<int> other_generator(int i, int j) {
+    while (i != j) { co_yield i++; }
+}
+
+/////////////////////
+// Demonstrate ability to yield nested sequences
+//
+// Need to use co_context::ranges::elements_of() to trigger yielding elements of
+// nested sequence.
+//
+// Supports yielding same generator type (with efficient resumption for
+// recursive cases)
+//
+// Also supports yielding any other range whose elements are convertible to
+// the current generator's elements.
+
+co_context::generator<uint64_t, uint64_t> nested_sequences_example() {
+    std::printf("yielding elements_of std::array\n");
+#if defined(__GNUC__) && !defined(__clang__)
+    co_yield co_context::ranges::elements_of(
+        std::array<const uint64_t, 5>{2, 4, 6, 8, 10}, {}
+    );
+#else
+    co_yield co_context::ranges::elements_of{
+        std::array<const uint64_t, 5>{2, 4, 6, 8, 10}};
+#endif
+    std::printf("yielding elements_of nested co_context::generator\n");
+    co_yield co_context::ranges::elements_of{fib(10)};
+
+    std::printf("yielding elements_of other kind of generator\n");
+    co_yield co_context::ranges::elements_of{other_generator(5, 8)};
+}
+
+//////////////////////////////////////
+// Following examples show difference between:
+//
+//                                    If I co_yield a...
+//                              X / X&&  | X&         | const X&
+//                           ------------+------------+-----------
+// - generator<X, X>               (same as generator<X, X&&>)
+// - generator<X, const X&>   ref        | ref        | ref
+// - generator<X, X&&>        ref        | ill-formed | ill-formed
+// - generator<X, X&>         ill-formed | ref        | ill-formed
+
+struct X {
+    int id;
+
+    X(int id) : id(id) { std::printf("X::X(%i)\n", id); }
+
+    X(const X &x) : id(x.id) { std::printf("X::X(copy %i)\n", id); }
+
+    X(X &&x) : id(std::exchange(x.id, -1)) {
+        std::printf("X::X(move %i)\n", id);
+    }
+
+    ~X() { std::printf("X::~X(%i)\n", id); }
+};
+
+co_context::generator<X> always_ref_example() {
+    co_yield X{1};
+    {
+        X x{2};
+        co_yield x;
+        assert(x.id == 2);
+    }
+    {
+        const X x{3};
+        co_yield x;
+        assert(x.id == 3);
+    }
+    {
+        X x{4};
+        co_yield std::move(x);
+    }
+}
+
+co_context::generator<X &&> xvalue_example() {
+    co_yield X{1};
+    X x{2};
+    co_yield x; // well-formed: generated element is copy of lvalue
+    assert(x.id == 2);
+    co_yield std::move(x);
+}
+
+co_context::generator<const X &> const_lvalue_example() {
+    co_yield X{1}; // OK
+    const X x{2};
+    co_yield x;            // OK
+    co_yield std::move(x); // OK: same as above
+}
+
+co_context::generator<X &> lvalue_example() {
+    // co_yield X{1}; // ill-formed: prvalue -> non-const lvalue
+    X x{2};
+    co_yield x; // OK
+    // co_yield std::move(x); // ill-formed: xvalue -> non-const lvalue
+}
+
+///////////////////////////////////
+// These examples show different usages of reference/value_type
+// template parameters
+
+// value_type = std::unique_ptr<int>
+// reference = std::unique_ptr<int>&&
+co_context::generator<std::unique_ptr<int> &&> unique_ints(const int high) {
+    for (auto i = 0; i < high; ++i) { co_yield std::make_unique<int>(i); }
+}
+
+// value_type = std::string_view
+// reference = std::string_view&&
+co_context::generator<std::string_view> string_views() {
+    co_yield "foo";
+    co_yield "bar";
+}
+
+// value_type = std::string
+// reference = std::string_view
+template<typename Allocator>
+co_context::generator<std::string_view, std::string>
+strings(std::allocator_arg_t, Allocator) {
+    co_yield {};
+    co_yield "start";
+    for (auto sv : string_views()) { co_yield std::string{sv} + '!'; }
+    co_yield "end";
+}
+
+// Resulting vector is deduced using ::value_type.
+template<std::ranges::input_range R>
+std::vector<std::ranges::range_value_t<R>> to_vector(R &&r) {
+    std::vector<std::ranges::range_value_t<R>> v;
+    for (auto &&x : r) { v.emplace_back(static_cast<decltype(x) &&>(x)); }
+    return v;
+}
+
+// zip() algorithm produces a generator of tuples where
+// the reference type is a tuple of references and
+// the value type is a tuple of values.
+template<std::ranges::range... Rs, std::size_t... Indices>
+co_context::generator<
+    std::tuple<std::ranges::range_reference_t<Rs>...>,
+    std::tuple<std::ranges::range_value_t<Rs>...>>
+zip_impl(std::index_sequence<Indices...>, Rs... rs) {
+    std::tuple<std::ranges::iterator_t<Rs>...> its{std::ranges::begin(rs)...};
+    std::tuple<std::ranges::sentinel_t<Rs>...> itEnds{std::ranges::end(rs)...};
+    while (((std::get<Indices>(its) != std::get<Indices>(itEnds)) && ...)) {
+        co_yield {*std::get<Indices>(its)...};
+        (++std::get<Indices>(its), ...);
+    }
+}
+
+template<std::ranges::range... Rs>
+co_context::generator<
+    std::tuple<std::ranges::range_reference_t<Rs>...>,
+    std::tuple<std::ranges::range_value_t<Rs>...>>
+zip(Rs &&...rs) {
+    return zip_impl(
+        std::index_sequence_for<Rs...>{},
+        std::views::all(std::forward<Rs>(rs))...
+    );
+}
+
+void value_type_example() {
+    std::vector<std::string_view> s1 = to_vector(string_views());
+    for (auto &s : s1) std::printf("\"%*s\"\n", (int)s.size(), s.data());
+
+    std::printf("\n");
+
+    std::vector<std::string> s2 =
+        to_vector(strings(std::allocator_arg, std::allocator<std::byte>{}));
+    for (auto &s : s2) { std::printf("\"%s\"\n", s.c_str()); }
+
+    std::printf("\n");
+
+    std::vector<std::tuple<std::string, std::string>> s3 = to_vector(
+        zip(strings(std::allocator_arg, std::allocator<std::byte>{}),
+            strings(std::allocator_arg, std::allocator<std::byte>{}))
+    );
+    for (auto &[a, b] : s3) {
+        std::printf("\"%s\", \"%s\"\n", a.c_str(), b.c_str());
+    }
+}
+
+template<typename T>
+struct stateful_allocator {
+    using value_type = T;
+
+    int id;
+
+    explicit stateful_allocator(int id) noexcept : id(id) {}
+
+    template<typename U>
+    stateful_allocator(const stateful_allocator<U> &x) : id(x.id) {}
+
+    T *allocate(std::size_t count) {
+        std::printf("stateful_allocator(%i).allocate(%zu)\n", id, count);
+        return std::allocator<T>().allocate(count);
+    }
+
+    void deallocate(T *ptr, std::size_t count) noexcept {
+        std::printf("stateful_allocator(%i).deallocate(%zu)\n", id, count);
+        std::allocator<T>().deallocate(ptr, count);
+    }
+
+    template<typename U>
+    bool operator==(const stateful_allocator<U> &x) const {
+        return this->id == x.id;
+    }
+};
+
+co_context::generator<int, void, std::allocator<std::byte>>
+stateless_example() {
+    co_yield 42;
+}
+
+co_context::generator<int, void, std::allocator<std::byte>>
+stateless_example(std::allocator_arg_t, std::allocator<std::byte>) {
+    co_yield 42;
+}
+
+template<typename Allocator>
+co_context::generator<int, void, Allocator>
+stateful_alloc_example(std::allocator_arg_t, Allocator) {
+    co_yield 42;
+}
+
+struct member_coro {
+    co_context::generator<int> f() const { co_yield 42; }
+};
+} // namespace
+
+int main() {
+    std::setvbuf(stdout, nullptr, _IOLBF, BUFSIZ);
+
+    std::printf("nested_sequences_example\n");
+    for (uint64_t a : nested_sequences_example()) {
+        std::printf("-> %" PRIu64 "\n", a);
+    }
+
+    std::printf("\nby_value_example\n");
+
+    for (auto &&x : always_ref_example()) { std::printf("-> %i\n", x.id); }
+
+    std::printf("\nby_rvalue_ref_example\n");
+
+    for (auto &&x : xvalue_example()) { std::printf("-> %i\n", x.id); }
+
+    std::printf("\nby_const_ref_example\n");
+
+    for (auto &&x : const_lvalue_example()) { std::printf("-> %i\n", x.id); }
+
+    std::printf("\nby_lvalue_ref_example\n");
+
+    for (auto &&x : lvalue_example()) { std::printf("-> %i\n", x.id); }
+
+    std::printf("\nvalue_type example\n");
+
+    value_type_example();
+
+    std::printf("\nmove_only example\n");
+
+    for (std::unique_ptr<int> ptr : unique_ints(5)) {
+        std::printf("-> %i\n", *ptr);
+    }
+
+    std::printf("\nstateless_alloc examples\n");
+
+    stateless_example();
+    stateless_example(std::allocator_arg, std::allocator<float>{});
+
+    std::printf("\nstateful_alloc example\n");
+
+    stateful_alloc_example(std::allocator_arg, stateful_allocator<double>{42});
+
+    member_coro m;
+    assert(*m.f().begin() == 42);
+}

--- a/test/nop.cpp
+++ b/test/nop.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
     times = atoi(argv[1]);
     times -= times % concur;
 
-    io_context context{256};
+    io_context context{32768};
 
     for (int i = 0; i < concur; ++i) context.co_spawn(gen_task());
 

--- a/test/rand4kr.cpp
+++ b/test/rand4kr.cpp
@@ -82,7 +82,7 @@ int main(int argc, char *argv[]) {
     file_size = argc == 4 ? atoll(argv[3]) : 60'000'000;
     // file_size = argc == 4 ? atoll(argv[3]) : 3'000'000'000;
 
-    io_context context{256};
+    io_context context{32768};
 
     alive.store(0);
     context.co_spawn([]() -> task<> {

--- a/test/rand4kr_blocking.cpp
+++ b/test/rand4kr_blocking.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
     times = atoi(argv[2]);
     file_size = argc == 4 ? atoll(argv[3]) : 1'000'000'000;
 
-    io_context context{256};
+    io_context context{32768};
 
     context.co_spawn([]() -> task<> {
         std::mt19937_64 rng(0);

--- a/test/rand4kr_callback.cpp
+++ b/test/rand4kr_callback.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[]) {
     // file_size = argc == 4 ? atoll(argv[3]) : 60'000'000;
     file_size = argc == 4 ? atoll(argv[3]) : 1'000'000'000;
 
-    io_context context{2048};
+    io_context context{32768};
 
     int concur = std::min(MAX_ON_FLY, times);
     remain.store(times - concur);

--- a/test/rand4kr_forloop.cpp
+++ b/test/rand4kr_forloop.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
     // file_size = argc == 4 ? atoll(argv[3]) : 60'000'000;
     file_size = argc == 4 ? atoll(argv[3]) : 15'000'000'000ULL;
 
-    co_context::io_context context{64};
+    co_context::io_context context{32768};
 
     const int concur = std::min<int>(MAX_ON_FLY, times);
     remain.store(times - concur);

--- a/test/rand4kr_multithread_blocking.cpp
+++ b/test/rand4kr_multithread_blocking.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[]) {
     // file_size = argc == 4 ? atoll(argv[3]) : 60'000'000;
     file_size = argc == 4 ? atoll(argv[3]) : 15'000'000'000ULL;
 
-    volatile co_context::io_context context{256};
+    volatile co_context::io_context context{32768};
 
     const int concur = std::min<int>(threads, times);
     remain.store(times - concur);

--- a/test/rand4kw_callback.cpp
+++ b/test/rand4kw_callback.cpp
@@ -79,7 +79,7 @@ int main(int argc, char *argv[]) {
     // file_size = argc == 4 ? atoll(argv[3]) : 60'000'000;
     file_size = argc == 4 ? atoll(argv[3]) : 1'000'000'000;
 
-    io_context context{256};
+    io_context context{32768};
 
     for (int i = 0; i < std::min(MAX_ON_FLY, times); ++i)
         context.co_spawn(run());


### PR DESCRIPTION
feat: add generator.
fix(example): set all io_contexts' capacity to 32768.
---
`co_context::generator` is supposed to be equivalent to `std::generator` in the future C++23.

So you will simply replace `co_context` by `std` in the future.