### PR TITLE
build(cmake): make `mimalloc` an option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,14 @@ cmake_minimum_required(VERSION 3.20.0)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 17)
+option(USE_MIMALLOC "Use mimalloc version 2.0 or above" ON)
 
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
     message("Setting default build type to Release")
 endif()
 
-project(co_context VERSION 0.3.0 LANGUAGES C CXX)
+project(co_context VERSION 0.4.0 LANGUAGES C CXX)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     if (${CMAKE_BUILD_TYPE} MATCHES Debug)
@@ -30,17 +31,21 @@ endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
-find_package(mimalloc 2.0 REQUIRED)
+if (USE_MIMALLOC)
+    find_package(mimalloc 2.0 REQUIRED)
+else()
+    find_package(mimalloc QUIET)
+endif()
+
+if (mi_version)
+    add_definitions(-DUSE_MIMALLOC)
+    message(NOTICE "mimalloc ${mi_version} enabled")
+else()
+    message(WARNING "mimalloc disabled")
+endif()
 
 add_subdirectory(./lib)
 
 add_subdirectory(./test)
+
 add_subdirectory(./example)
-# add_subdirectory(./src)
-
-# include(CTest)
-# enable_testing()
-
-# set(CPACK_PROJECT_NAME ${PROJECT_NAME})
-# set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
-# include(CPack)

--- a/lib/co_context/CMakeLists.txt
+++ b/lib/co_context/CMakeLists.txt
@@ -1,10 +1,8 @@
-
-find_package(mimalloc 2.0 REQUIRED)
-
-
 include_directories(${PROJECT_SOURCE_DIR}/include)
 file(GLOB_RECURSE sources CONFIGURE_DEPENDS *.cpp)
 
 add_library(co_context OBJECT ${sources})
 
-target_link_libraries(co_context PUBLIC mimalloc)
+if (mi_version)
+    target_link_libraries(co_context PUBLIC mimalloc)
+endif()

--- a/lib/co_context/io_context.cpp
+++ b/lib/co_context/io_context.cpp
@@ -1,4 +1,6 @@
+#ifdef USE_MIMALLOC
 #include <mimalloc-new-delete.h>
+#endif
 #include "co_context/io_context.hpp"
 #include "co_context/utility/set_cpu_affinity.hpp"
 #include "co_context/co/semaphore.hpp"


### PR DESCRIPTION
/CMakeLists.txt now add an option for `mimalloc`. The default is `ON`, which means `mimalloc` version 2.0 or above is required.