### PR TITLE
Full SQE Support in io_uring; Lifetime of task fixed

### DIFF
--- a/example/netcat.cpp
+++ b/example/netcat.cpp
@@ -21,7 +21,9 @@ task<> send_session(Socket sock) {
     int nr = co_await lazy::read(STDIN_FILENO, buf);
 
     while (nr > 0) {
-        nr = co_await (sock.send({buf, (size_t)nr}) && lazy::read(STDIN_FILENO, buf));
+        nr = co_await (
+            sock.send({buf, (size_t)nr}) && lazy::read(STDIN_FILENO, buf)
+        );
     }
 }
 

--- a/include/co_context/detail/worker_meta.hpp
+++ b/include/co_context/detail/worker_meta.hpp
@@ -17,11 +17,8 @@ class io_context;
 namespace detail {
 
     struct worker_meta final {
-        enum class [[deprecated]] worker_state : uint8_t {
-            running,
-            idle,
-            blocked
-        };
+        enum class [[deprecated]] worker_state : uint8_t{
+            running, idle, blocked};
 
         using cur_t = config::cur_t;
 

--- a/include/co_context/eager_io.hpp
+++ b/include/co_context/eager_io.hpp
@@ -491,7 +491,8 @@ namespace eager {
         int flags,
         uint32_t file_index
     ) noexcept {
-        return detail::eager_accept_direct{fd, addr, addrlen, flags, file_index};
+        return detail::eager_accept_direct{
+            fd, addr, addrlen, flags, file_index};
     }
 
     inline detail::eager_recv

--- a/include/co_context/eager_io.hpp
+++ b/include/co_context/eager_io.hpp
@@ -249,7 +249,7 @@ namespace detail {
         inline eager_sync_file_range(
             int fd, uint32_t len, uint64_t offset, int flags
         ) noexcept {
-            sqe->prepare_syncFileRange(fd, len, offset, flags);
+            sqe->prepare_sync_file_range(fd, len, offset, flags);
             submit();
         }
     };

--- a/include/co_context/eager_io.hpp
+++ b/include/co_context/eager_io.hpp
@@ -385,7 +385,7 @@ namespace detail {
 
     struct eager_timeout_timespec : eager_awaiter {
         inline eager_timeout_timespec(
-            __kernel_timespec *ts, unsigned int count, unsigned int flags
+            const __kernel_timespec &ts, unsigned int count, unsigned int flags
         ) noexcept {
             sqe->prepare_timeout(ts, count, flags);
             submit();
@@ -406,7 +406,7 @@ namespace detail {
             ts.tv_nsec =
                 duration_cast<chrono::duration<long long, std::nano>>(duration)
                     .count();
-            sqe->prepare_timeout(&ts, 0, flags);
+            sqe->prepare_timeout(ts, 0, flags);
             submit();
         }
     };
@@ -632,7 +632,7 @@ namespace eager {
      * @return eager_awaiter
      */
     inline detail::eager_timeout_timespec timeout(
-        __kernel_timespec *ts, unsigned int count, unsigned int flags
+        const __kernel_timespec &ts, unsigned int count, unsigned int flags
     ) noexcept {
         return detail::eager_timeout_timespec{ts, count, flags};
     }

--- a/include/co_context/eager_io.hpp
+++ b/include/co_context/eager_io.hpp
@@ -106,7 +106,7 @@ namespace detail {
         inline eager_read(
             int fd, std::span<char> buf, uint64_t offset
         ) noexcept {
-            sqe->prepare_read(fd, buf, offset);
+            sqe->prep_read(fd, buf, offset);
             submit();
         }
     };
@@ -115,7 +115,7 @@ namespace detail {
         inline eager_readv(
             int fd, std::span<const iovec> iovecs, uint64_t offset
         ) noexcept {
-            sqe->prepare_readv(fd, iovecs, offset);
+            sqe->prep_readv(fd, iovecs, offset);
             submit();
         }
     };
@@ -124,7 +124,7 @@ namespace detail {
         inline eager_read_fixed(
             int fd, std::span<char> buf, uint64_t offset, uint16_t bufIndex
         ) noexcept {
-            sqe->prepare_read_fixed(fd, buf, offset, bufIndex);
+            sqe->prep_read_fixed(fd, buf, offset, bufIndex);
             submit();
         }
     };
@@ -133,7 +133,7 @@ namespace detail {
         inline eager_write(
             int fd, std::span<const char> buf, uint64_t offset
         ) noexcept {
-            sqe->prepare_write(fd, buf, offset);
+            sqe->prep_write(fd, buf, offset);
             submit();
         }
     };
@@ -142,7 +142,7 @@ namespace detail {
         inline eager_writev(
             int fd, std::span<const iovec> iovecs, uint64_t offset
         ) noexcept {
-            sqe->prepare_writev(fd, iovecs, offset);
+            sqe->prep_writev(fd, iovecs, offset);
             submit();
         }
     };
@@ -154,7 +154,7 @@ namespace detail {
             uint64_t offset,
             uint16_t bufIndex
         ) noexcept {
-            sqe->prepare_write_fixed(fd, buf, offset, bufIndex);
+            sqe->prep_write_fixed(fd, buf, offset, bufIndex);
             submit();
         }
     };
@@ -163,7 +163,7 @@ namespace detail {
         inline eager_accept(
             int fd, sockaddr *addr, socklen_t *addrlen, int flags
         ) noexcept {
-            sqe->prepare_accept(fd, addr, addrlen, flags);
+            sqe->prep_accept(fd, addr, addrlen, flags);
             submit();
         }
     };
@@ -176,21 +176,21 @@ namespace detail {
             int flags,
             uint32_t file_index
         ) noexcept {
-            sqe->prepare_accept_direct(fd, addr, addrlen, flags, file_index);
+            sqe->prep_accept_direct(fd, addr, addrlen, flags, file_index);
             submit();
         }
     };
 
     struct eager_recv : eager_awaiter {
         inline eager_recv(int sockfd, std::span<char> buf, int flags) noexcept {
-            sqe->prepare_recv(sockfd, buf, flags);
+            sqe->prep_recv(sockfd, buf, flags);
             submit();
         }
     };
 
     struct eager_recvmsg : eager_awaiter {
         inline eager_recvmsg(int fd, msghdr *msg, unsigned int flags) noexcept {
-            sqe->prepare_recvmsg(fd, msg, flags);
+            sqe->prep_recvmsg(fd, msg, flags);
             submit();
         }
     };
@@ -199,7 +199,7 @@ namespace detail {
         inline eager_send(
             int sockfd, std::span<const char> buf, int flags
         ) noexcept {
-            sqe->prepare_send(sockfd, buf, flags);
+            sqe->prep_send(sockfd, buf, flags);
             submit();
         }
     };
@@ -208,7 +208,7 @@ namespace detail {
         inline eager_sendmsg(
             int fd, const msghdr *msg, unsigned int flags
         ) noexcept {
-            sqe->prepare_sendmsg(fd, msg, flags);
+            sqe->prep_sendmsg(fd, msg, flags);
             submit();
         }
     };
@@ -217,14 +217,14 @@ namespace detail {
         inline eager_connect(
             int sockfd, const sockaddr *addr, socklen_t addrlen
         ) noexcept {
-            sqe->prepare_connect(sockfd, addr, addrlen);
+            sqe->prep_connect(sockfd, addr, addrlen);
             submit();
         }
     };
 
     struct eager_close : eager_awaiter {
         inline eager_close(int fd) noexcept {
-            sqe->prepare_close(fd);
+            sqe->prep_close(fd);
             submit();
         }
     };
@@ -232,7 +232,7 @@ namespace detail {
     struct eager_shutdown : eager_awaiter {
         [[nodiscard("Did you forget to co_await?"
         )]] inline eager_shutdown(int fd, int how) noexcept {
-            sqe->prepare_shutdown(fd, how);
+            sqe->prep_shutdown(fd, how);
             submit();
         }
     };
@@ -240,7 +240,7 @@ namespace detail {
     struct eager_fsync : eager_awaiter {
         [[nodiscard("Did you forget to co_await?"
         )]] inline eager_fsync(int fd, uint32_t fsync_flags) noexcept {
-            sqe->prepare_fsync(fd, fsync_flags);
+            sqe->prep_fsync(fd, fsync_flags);
             submit();
         }
     };
@@ -249,7 +249,7 @@ namespace detail {
         inline eager_sync_file_range(
             int fd, uint32_t len, uint64_t offset, int flags
         ) noexcept {
-            sqe->prepare_sync_file_range(fd, len, offset, flags);
+            sqe->prep_sync_file_range(fd, len, offset, flags);
             submit();
         }
     };
@@ -257,7 +257,7 @@ namespace detail {
     struct eager_uring_nop : eager_awaiter {
         [[nodiscard("Did you forget to co_await?"
         )]] inline eager_uring_nop() noexcept {
-            sqe->prepare_nop();
+            sqe->prep_nop();
             submit();
         }
     };
@@ -265,7 +265,7 @@ namespace detail {
     struct eager_files_update : eager_awaiter {
         [[nodiscard("Did you forget to co_await?"
         )]] inline eager_files_update(std::span<int> fds, int offset) noexcept {
-            sqe->prepare_files_update(fds, offset);
+            sqe->prep_files_update(fds, offset);
             submit();
         }
     };
@@ -274,7 +274,7 @@ namespace detail {
         inline eager_fallocate(
             int fd, int mode, off_t offset, off_t len
         ) noexcept {
-            sqe->prepare_fallocate(fd, mode, offset, len);
+            sqe->prep_fallocate(fd, mode, offset, len);
             submit();
         }
     };
@@ -283,7 +283,7 @@ namespace detail {
         inline eager_openat(
             int dfd, const char *path, int flags, mode_t mode
         ) noexcept {
-            sqe->prepare_openat(dfd, path, flags, mode);
+            sqe->prep_openat(dfd, path, flags, mode);
             submit();
         }
     };
@@ -297,7 +297,7 @@ namespace detail {
             mode_t mode,
             unsigned file_index
         ) noexcept {
-            sqe->prepare_openat_direct(dfd, path, flags, mode, file_index);
+            sqe->prep_openat_direct(dfd, path, flags, mode, file_index);
             submit();
         }
     };
@@ -306,7 +306,7 @@ namespace detail {
         inline eager_openat2(
             int dfd, const char *path, open_how *how
         ) noexcept {
-            sqe->prepare_openat2(dfd, path, how);
+            sqe->prep_openat2(dfd, path, how);
             submit();
         }
     };
@@ -316,7 +316,7 @@ namespace detail {
         inline eager_openat2_direct(
             int dfd, const char *path, open_how *how, unsigned int file_index
         ) noexcept {
-            sqe->prepare_openat2_direct(dfd, path, how, file_index);
+            sqe->prep_openat2_direct(dfd, path, how, file_index);
             submit();
         }
     };
@@ -329,14 +329,14 @@ namespace detail {
             unsigned int mask,
             struct statx *statxbuf
         ) noexcept {
-            sqe->prepare_statx(dfd, path, flags, mask, statxbuf);
+            sqe->prep_statx(dfd, path, flags, mask, statxbuf);
             submit();
         }
     };
 
     struct eager_unlinkat : eager_awaiter {
         inline eager_unlinkat(int dfd, const char *path, int flags) noexcept {
-            sqe->prepare_unlinkat(dfd, path, flags);
+            sqe->prep_unlinkat(dfd, path, flags);
             submit();
         }
     };
@@ -349,14 +349,14 @@ namespace detail {
             const char *newpath,
             int flags
         ) noexcept {
-            sqe->prepare_renameat(olddfd, oldpath, newdfd, newpath, flags);
+            sqe->prep_renameat(olddfd, oldpath, newdfd, newpath, flags);
             submit();
         }
     };
 
     struct eager_mkdirat : eager_awaiter {
         inline eager_mkdirat(int dfd, const char *path, mode_t mode) noexcept {
-            sqe->prepare_mkdirat(dfd, path, mode);
+            sqe->prep_mkdirat(dfd, path, mode);
             submit();
         }
     };
@@ -365,7 +365,7 @@ namespace detail {
         inline eager_symlinkat(
             const char *target, int newdirfd, const char *linkpath
         ) noexcept {
-            sqe->prepare_symlinkat(target, newdirfd, linkpath);
+            sqe->prep_symlinkat(target, newdirfd, linkpath);
             submit();
         }
     };
@@ -378,7 +378,7 @@ namespace detail {
             const char *newpath,
             int flags
         ) noexcept {
-            sqe->prepare_linkat(olddfd, oldpath, newdfd, newpath, flags);
+            sqe->prep_linkat(olddfd, oldpath, newdfd, newpath, flags);
             submit();
         }
     };
@@ -387,7 +387,7 @@ namespace detail {
         inline eager_timeout_timespec(
             const __kernel_timespec &ts, unsigned int count, unsigned int flags
         ) noexcept {
-            sqe->prepare_timeout(ts, count, flags);
+            sqe->prep_timeout(ts, count, flags);
             submit();
         }
     };
@@ -406,7 +406,7 @@ namespace detail {
             ts.tv_nsec =
                 duration_cast<chrono::duration<long long, std::nano>>(duration)
                     .count();
-            sqe->prepare_timeout(ts, 0, flags);
+            sqe->prep_timeout(ts, 0, flags);
             submit();
         }
     };
@@ -420,7 +420,7 @@ namespace detail {
             unsigned int nbytes,
             unsigned int splice_flags
         ) noexcept {
-            sqe->prepare_splice(
+            sqe->prep_splice(
                 fd_in, off_in, fd_out, off_out, nbytes, splice_flags
             );
             submit();
@@ -434,7 +434,7 @@ namespace detail {
             unsigned int nbytes,
             unsigned int splice_flags
         ) noexcept {
-            sqe->prepare_tee(fd_in, fd_out, nbytes, splice_flags);
+            sqe->prep_tee(fd_in, fd_out, nbytes, splice_flags);
             submit();
         }
     };

--- a/include/co_context/generator.hpp
+++ b/include/co_context/generator.hpp
@@ -308,6 +308,8 @@ class _Gen_promise_base {
     // clang-format on
 
     // clang-format off
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
     template <::std::ranges::input_range _Rng, class _Alloc>
         requires std::convertible_to<::std::ranges::range_reference_t<_Rng>, _Yielded>
     [[nodiscard]] auto yield_value(::co_context::ranges::elements_of<_Rng, _Alloc> _Elem) noexcept {
@@ -325,6 +327,7 @@ class _Gen_promise_base {
               ::std::ranges::begin(_Elem.range),
               ::std::ranges::end(_Elem.range))};
     }
+#pragma GCC diagnostic pop
 
     void await_transform() = delete;
 

--- a/include/co_context/lazy_io.hpp
+++ b/include/co_context/lazy_io.hpp
@@ -131,7 +131,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_read(
             int fd, std::span<char> buf, uint64_t offset
         ) noexcept {
-            sqe->prepare_read(fd, buf, offset);
+            sqe->prep_read(fd, buf, offset);
         }
     };
 
@@ -139,7 +139,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_readv(
             int fd, std::span<const iovec> iovecs, uint64_t offset
         ) noexcept {
-            sqe->prepare_readv(fd, iovecs, offset);
+            sqe->prep_readv(fd, iovecs, offset);
         }
     };
 
@@ -147,7 +147,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_read_fixed(
             int fd, std::span<char> buf, uint64_t offset, uint16_t bufIndex
         ) noexcept {
-            sqe->prepare_read_fixed(fd, buf, offset, bufIndex);
+            sqe->prep_read_fixed(fd, buf, offset, bufIndex);
         }
     };
 
@@ -155,7 +155,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_write(
             int fd, std::span<const char> buf, uint64_t offset
         ) noexcept {
-            sqe->prepare_write(fd, buf, offset);
+            sqe->prep_write(fd, buf, offset);
         }
     };
 
@@ -163,7 +163,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_writev(
             int fd, std::span<const iovec> iovecs, uint64_t offset
         ) noexcept {
-            sqe->prepare_writev(fd, iovecs, offset);
+            sqe->prep_writev(fd, iovecs, offset);
         }
     };
 
@@ -174,7 +174,7 @@ namespace detail {
             uint64_t offset,
             uint16_t bufIndex
         ) noexcept {
-            sqe->prepare_write_fixed(fd, buf, offset, bufIndex);
+            sqe->prep_write_fixed(fd, buf, offset, bufIndex);
         }
     };
 
@@ -182,7 +182,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_accept(
             int fd, sockaddr *addr, socklen_t *addrlen, int flags
         ) noexcept {
-            sqe->prepare_accept(fd, addr, addrlen, flags);
+            sqe->prep_accept(fd, addr, addrlen, flags);
         }
     };
 
@@ -194,21 +194,21 @@ namespace detail {
             int flags,
             uint32_t file_index
         ) noexcept {
-            sqe->prepare_accept_direct(fd, addr, addrlen, flags, file_index);
+            sqe->prep_accept_direct(fd, addr, addrlen, flags, file_index);
         }
     };
 
     struct lazy_cancel : lazy_awaiter {
         [[nodiscard("Did you forget to co_await?"
         )]] inline lazy_cancel(uint64_t user_data, int flags) noexcept {
-            sqe->prepare_cancle(user_data, flags);
+            sqe->prep_cancle(user_data, flags);
         }
     };
 
     struct lazy_cancel_fd : lazy_awaiter {
         [[nodiscard("Did you forget to co_await?"
         )]] inline lazy_cancel_fd(int fd, unsigned int flags) noexcept {
-            sqe->prepare_cancle_fd(fd, flags);
+            sqe->prep_cancle_fd(fd, flags);
         }
     };
 
@@ -216,7 +216,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_recv(
             int sockfd, std::span<char> buf, int flags
         ) noexcept {
-            sqe->prepare_recv(sockfd, buf, flags);
+            sqe->prep_recv(sockfd, buf, flags);
         }
     };
 
@@ -224,7 +224,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_recvmsg(
             int fd, msghdr *msg, unsigned int flags
         ) noexcept {
-            sqe->prepare_recvmsg(fd, msg, flags);
+            sqe->prep_recvmsg(fd, msg, flags);
         }
     };
 
@@ -232,7 +232,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_send(
             int sockfd, std::span<const char> buf, int flags
         ) noexcept {
-            sqe->prepare_send(sockfd, buf, flags);
+            sqe->prep_send(sockfd, buf, flags);
         }
     };
 
@@ -240,7 +240,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_sendmsg(
             int fd, const msghdr *msg, unsigned int flags
         ) noexcept {
-            sqe->prepare_sendmsg(fd, msg, flags);
+            sqe->prep_sendmsg(fd, msg, flags);
         }
     };
 
@@ -248,28 +248,28 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_connect(
             int sockfd, const sockaddr *addr, socklen_t addrlen
         ) noexcept {
-            sqe->prepare_connect(sockfd, addr, addrlen);
+            sqe->prep_connect(sockfd, addr, addrlen);
         }
     };
 
     struct lazy_close : lazy_awaiter {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_close(int fd
         ) noexcept {
-            sqe->prepare_close(fd);
+            sqe->prep_close(fd);
         }
     };
 
     struct lazy_shutdown : lazy_awaiter {
         [[nodiscard("Did you forget to co_await?"
         )]] inline lazy_shutdown(int fd, int how) noexcept {
-            sqe->prepare_shutdown(fd, how);
+            sqe->prep_shutdown(fd, how);
         }
     };
 
     struct lazy_fsync : lazy_awaiter {
         [[nodiscard("Did you forget to co_await?"
         )]] inline lazy_fsync(int fd, uint32_t fsync_flags) noexcept {
-            sqe->prepare_fsync(fd, fsync_flags);
+            sqe->prep_fsync(fd, fsync_flags);
         }
     };
 
@@ -277,21 +277,21 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_sync_file_range(
             int fd, uint32_t len, uint64_t offset, int flags
         ) noexcept {
-            sqe->prepare_sync_file_range(fd, len, offset, flags);
+            sqe->prep_sync_file_range(fd, len, offset, flags);
         }
     };
 
     struct lazy_uring_nop : lazy_awaiter {
         [[nodiscard("Did you forget to co_await?"
         )]] inline lazy_uring_nop() noexcept {
-            sqe->prepare_nop();
+            sqe->prep_nop();
         }
     };
 
     struct lazy_files_update : lazy_awaiter {
         [[nodiscard("Did you forget to co_await?"
         )]] inline lazy_files_update(std::span<int> fds, int offset) noexcept {
-            sqe->prepare_files_update(fds, offset);
+            sqe->prep_files_update(fds, offset);
         }
     };
 
@@ -299,7 +299,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_fallocate(
             int fd, int mode, off_t offset, off_t len
         ) noexcept {
-            sqe->prepare_fallocate(fd, mode, offset, len);
+            sqe->prep_fallocate(fd, mode, offset, len);
         }
     };
 
@@ -307,7 +307,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_openat(
             int dfd, const char *path, int flags, mode_t mode
         ) noexcept {
-            sqe->prepare_openat(dfd, path, flags, mode);
+            sqe->prep_openat(dfd, path, flags, mode);
         }
     };
 
@@ -320,7 +320,7 @@ namespace detail {
             mode_t mode,
             unsigned file_index
         ) noexcept {
-            sqe->prepare_openat_direct(dfd, path, flags, mode, file_index);
+            sqe->prep_openat_direct(dfd, path, flags, mode, file_index);
         }
     };
 
@@ -328,7 +328,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_openat2(
             int dfd, const char *path, open_how *how
         ) noexcept {
-            sqe->prepare_openat2(dfd, path, how);
+            sqe->prep_openat2(dfd, path, how);
         }
     };
 
@@ -337,7 +337,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_openat2_direct(
             int dfd, const char *path, open_how *how, unsigned int file_index
         ) noexcept {
-            sqe->prepare_openat2_direct(dfd, path, how, file_index);
+            sqe->prep_openat2_direct(dfd, path, how, file_index);
         }
     };
 
@@ -349,7 +349,7 @@ namespace detail {
             unsigned int mask,
             struct statx *statxbuf
         ) noexcept {
-            sqe->prepare_statx(dfd, path, flags, mask, statxbuf);
+            sqe->prep_statx(dfd, path, flags, mask, statxbuf);
         }
     };
 
@@ -357,7 +357,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_unlinkat(
             int dfd, const char *path, int flags
         ) noexcept {
-            sqe->prepare_unlinkat(dfd, path, flags);
+            sqe->prep_unlinkat(dfd, path, flags);
         }
     };
 
@@ -369,7 +369,7 @@ namespace detail {
             const char *newpath,
             int flags
         ) noexcept {
-            sqe->prepare_renameat(olddfd, oldpath, newdfd, newpath, flags);
+            sqe->prep_renameat(olddfd, oldpath, newdfd, newpath, flags);
         }
     };
 
@@ -377,7 +377,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_mkdirat(
             int dfd, const char *path, mode_t mode
         ) noexcept {
-            sqe->prepare_mkdirat(dfd, path, mode);
+            sqe->prep_mkdirat(dfd, path, mode);
         }
     };
 
@@ -385,7 +385,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_symlinkat(
             const char *target, int newdirfd, const char *linkpath
         ) noexcept {
-            sqe->prepare_symlinkat(target, newdirfd, linkpath);
+            sqe->prep_symlinkat(target, newdirfd, linkpath);
         }
     };
 
@@ -397,7 +397,7 @@ namespace detail {
             const char *newpath,
             int flags
         ) noexcept {
-            sqe->prepare_linkat(olddfd, oldpath, newdfd, newpath, flags);
+            sqe->prep_linkat(olddfd, oldpath, newdfd, newpath, flags);
         }
     };
 
@@ -406,7 +406,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_timeout_timespec(
             const __kernel_timespec &ts, unsigned int count, unsigned int flags
         ) noexcept {
-            sqe->prepare_timeout(ts, count, flags);
+            sqe->prep_timeout(ts, count, flags);
         }
 
       protected:
@@ -443,7 +443,7 @@ namespace detail {
             std::chrono::duration<Rep, Period> duration, unsigned int flags
         ) noexcept
             : lazy_timeout_base(duration) {
-            sqe->prepare_timeout(ts, 0, flags);
+            sqe->prep_timeout(ts, 0, flags);
         }
     };
 
@@ -453,7 +453,7 @@ namespace detail {
             std::chrono::duration<Rep, Period> duration, unsigned int flags
         ) noexcept
             : lazy_timeout_base(duration) {
-            sqe->prepare_link_timeout(this->ts, flags);
+            sqe->prep_link_timeout(this->ts, flags);
         }
     };
 
@@ -504,7 +504,7 @@ namespace detail {
             unsigned int nbytes,
             unsigned int splice_flags
         ) noexcept {
-            sqe->prepare_splice(
+            sqe->prep_splice(
                 fd_in, off_in, fd_out, off_out, nbytes, splice_flags
             );
         }
@@ -517,7 +517,7 @@ namespace detail {
             unsigned int nbytes,
             unsigned int splice_flags
         ) noexcept {
-            sqe->prepare_tee(fd_in, fd_out, nbytes, splice_flags);
+            sqe->prep_tee(fd_in, fd_out, nbytes, splice_flags);
         }
     };
 

--- a/include/co_context/lazy_io.hpp
+++ b/include/co_context/lazy_io.hpp
@@ -277,7 +277,7 @@ namespace detail {
         [[nodiscard("Did you forget to co_await?")]] inline lazy_sync_file_range(
             int fd, uint32_t len, uint64_t offset, int flags
         ) noexcept {
-            sqe->prepare_syncFileRange(fd, len, offset, flags);
+            sqe->prepare_sync_file_range(fd, len, offset, flags);
         }
     };
 

--- a/include/co_context/lazy_io.hpp
+++ b/include/co_context/lazy_io.hpp
@@ -404,7 +404,7 @@ namespace detail {
     struct lazy_timeout_timespec : lazy_awaiter {
       public:
         [[nodiscard("Did you forget to co_await?")]] inline lazy_timeout_timespec(
-            __kernel_timespec *ts, unsigned int count, unsigned int flags
+            const __kernel_timespec &ts, unsigned int count, unsigned int flags
         ) noexcept {
             sqe->prepare_timeout(ts, count, flags);
         }
@@ -443,7 +443,7 @@ namespace detail {
             std::chrono::duration<Rep, Period> duration, unsigned int flags
         ) noexcept
             : lazy_timeout_base(duration) {
-            sqe->prepare_timeout(&ts, 0, flags);
+            sqe->prepare_timeout(ts, 0, flags);
         }
     };
 
@@ -453,7 +453,7 @@ namespace detail {
             std::chrono::duration<Rep, Period> duration, unsigned int flags
         ) noexcept
             : lazy_timeout_base(duration) {
-            sqe->prepare_link_timeout(&this->ts, flags);
+            sqe->prepare_link_timeout(this->ts, flags);
         }
     };
 
@@ -725,7 +725,7 @@ inline namespace lazy {
      * @return lazy_awaiter
      */
     inline detail::lazy_timeout_timespec timeout(
-        __kernel_timespec *ts, unsigned int count, unsigned int flags
+        const __kernel_timespec &ts, unsigned int count, unsigned int flags
     ) noexcept {
         return detail::lazy_timeout_timespec{ts, count, flags};
     }

--- a/include/co_context/utility/timing.hpp
+++ b/include/co_context/utility/timing.hpp
@@ -2,17 +2,15 @@
 
 #include <concepts>
 #include <chrono>
-#include "co_context/log/log.hpp"
 
 template<std::invocable F>
-[[maybe_unused]] auto hostTiming(const F &func) {
+[[maybe_unused]] auto host_timing(const F &func) {
     auto start = std::chrono::steady_clock::now();
 
     func();
 
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double, std::micro> duration = end - start;
-    co_context::log::v("Host Time = %7.3f us.\n", duration.count());
     return duration;
 }
 

--- a/include/uring/sq_entry.hpp
+++ b/include/uring/sq_entry.hpp
@@ -194,9 +194,9 @@ class sq_entry final : private io_uring_sqe {
     }
 
     inline sq_entry &prepare_timeout(
-        __kernel_timespec *ts, unsigned count, unsigned flags
+        const __kernel_timespec &ts, unsigned count, unsigned flags
     ) noexcept {
-        prepare_rw(IORING_OP_TIMEOUT, -1, ts, 1, count);
+        prepare_rw(IORING_OP_TIMEOUT, -1, &ts, 1, count);
         this->timeout_flags = flags;
         return *this;
     }
@@ -212,11 +212,11 @@ class sq_entry final : private io_uring_sqe {
     }
 
     inline sq_entry &prepare_timeout_rpdate(
-        __kernel_timespec *ts, uint64_t user_data, unsigned flags
+        const __kernel_timespec &ts, uint64_t user_data, unsigned flags
     ) noexcept {
         prepare_rw(
             IORING_OP_TIMEOUT_REMOVE, -1, reinterpret_cast<void *>(user_data),
-            0, (uintptr_t)ts
+            0, (uintptr_t)(&ts)
         );
         this->timeout_flags = flags | IORING_TIMEOUT_UPDATE;
         return *this;
@@ -256,9 +256,9 @@ class sq_entry final : private io_uring_sqe {
     }
 
     inline sq_entry &prepare_link_timeout(
-        struct __kernel_timespec *ts, unsigned flags
+        const __kernel_timespec &ts, unsigned flags
     ) noexcept {
-        prepare_rw(IORING_OP_LINK_TIMEOUT, -1, ts, 1, 0);
+        prepare_rw(IORING_OP_LINK_TIMEOUT, -1, &ts, 1, 0);
         this->timeout_flags = flags;
         return *this;
     }

--- a/include/uring/sq_entry.hpp
+++ b/include/uring/sq_entry.hpp
@@ -255,8 +255,9 @@ class sq_entry final : private io_uring_sqe {
         return *this;
     }
 
-    inline sq_entry &
-    prepare_link_timeout(struct __kernel_timespec *ts, unsigned flags) noexcept {
+    inline sq_entry &prepare_link_timeout(
+        struct __kernel_timespec *ts, unsigned flags
+    ) noexcept {
         prepare_rw(IORING_OP_LINK_TIMEOUT, -1, ts, 1, 0);
         this->timeout_flags = flags;
         return *this;
@@ -291,8 +292,9 @@ class sq_entry final : private io_uring_sqe {
      *
      * available @since Linux 5.20
      */
-    inline sq_entry &
-    prepare_recv_multishot(int sockfd, std::span<char> buf, int flags) noexcept {
+    inline sq_entry &prepare_recv_multishot(
+        int sockfd, std::span<char> buf, int flags
+    ) noexcept {
         prepare_recv(sockfd, buf, flags);
         this->ioprio |= IORING_RECV_MULTISHOT;
         return *this;
@@ -358,7 +360,8 @@ class sq_entry final : private io_uring_sqe {
     inline sq_entry &prepare_openat2_direct(
         int dfd, const char *path, struct open_how *how, unsigned file_index
     ) noexcept {
-        return prepare_openat2(dfd, path, how).set_target_fixed_file(file_index);
+        return prepare_openat2(dfd, path, how)
+            .set_target_fixed_file(file_index);
     }
 
     inline sq_entry &prepare_provide_buffers(
@@ -512,7 +515,9 @@ class sq_entry final : private io_uring_sqe {
         unsigned int nbytes,
         unsigned int splice_flags
     ) noexcept {
-        prepare_rw(IORING_OP_SPLICE, fd_out, nullptr, nbytes, (uint64_t)off_out);
+        prepare_rw(
+            IORING_OP_SPLICE, fd_out, nullptr, nbytes, (uint64_t)off_out
+        );
         this->splice_off_in = (uint64_t)off_in;
         this->splice_flags = splice_flags;
         this->splice_fd_in = fd_in;

--- a/include/uring/sq_entry.hpp
+++ b/include/uring/sq_entry.hpp
@@ -255,9 +255,8 @@ class sq_entry final : private io_uring_sqe {
         return *this;
     }
 
-    inline sq_entry &prepare_link_timeout(
-        const __kernel_timespec &ts, unsigned flags
-    ) noexcept {
+    inline sq_entry &
+    prepare_link_timeout(const __kernel_timespec &ts, unsigned flags) noexcept {
         prepare_rw(IORING_OP_LINK_TIMEOUT, -1, &ts, 1, 0);
         this->timeout_flags = flags;
         return *this;
@@ -310,7 +309,7 @@ class sq_entry final : private io_uring_sqe {
         return *this;
     }
 
-    inline sq_entry &prepare_syncFileRange(
+    inline sq_entry &prepare_sync_file_range(
         int fd, uint32_t len, uint64_t offset, int flags
     ) noexcept {
         prepare_rw(IORING_OP_SYNC_FILE_RANGE, fd, nullptr, len, offset);
@@ -374,7 +373,7 @@ class sq_entry final : private io_uring_sqe {
         return *this;
     }
 
-    inline sq_entry &prepare_provide_buffers(int nr, int bgid) noexcept {
+    inline sq_entry &prepare_remove_buffers(int nr, int bgid) noexcept {
         prepare_rw(IORING_OP_REMOVE_BUFFERS, nr, nullptr, 0, 0);
         this->buf_group = (uint16_t)bgid;
         return *this;
@@ -413,6 +412,10 @@ class sq_entry final : private io_uring_sqe {
         prepare_rw(IORING_OP_UNLINKAT, dfd, path, 0, 0);
         this->unlink_flags = (uint32_t)flags;
         return *this;
+    }
+
+    inline sq_entry &prepare_unlink(const char *path, int flags) noexcept {
+        return prepare_unlinkat(AT_FDCWD, path, flags);
     }
 
     inline sq_entry &prepare_renameat(

--- a/include/uring/uring.hpp
+++ b/include/uring/uring.hpp
@@ -149,6 +149,8 @@ class [[nodiscard]] uring final {
     ) noexcept;
 #endif
 
+    void cq_advance(unsigned num) noexcept;
+
     void seen_cq_entry(const cq_entry *cqe) noexcept;
 
     int register_ring_fd();
@@ -186,8 +188,6 @@ class [[nodiscard]] uring final {
     bool is_cq_ring_need_flush() const noexcept;
 
     bool is_cq_ring_need_enter() const noexcept;
-
-    void cq_advance(unsigned num) noexcept;
 
     void buf_ring_cq_advance(buf_ring &br, unsigned count) noexcept;
 

--- a/include/uring/utility/io_helper.hpp
+++ b/include/uring/utility/io_helper.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "../io_uring.h"
+#include <sys/socket.h>
+#include <span>
+
+namespace liburingcxx {
+
+static inline io_uring_recvmsg_out *
+recvmsg_validate(std::span<char> buf, msghdr *msgh) noexcept {
+    const size_t header =
+        msgh->msg_controllen + msgh->msg_namelen + sizeof(io_uring_recvmsg_out);
+    if (buf.size() < header) return nullptr;
+    return reinterpret_cast<io_uring_recvmsg_out *>(buf.data());
+}
+
+static inline void *recvmsg_name(io_uring_recvmsg_out *o) {
+    return (void *)&o[1];
+}
+
+static inline cmsghdr *
+recvmsg_cmsg_firsthdr(io_uring_recvmsg_out *o, msghdr *msgh) {
+    if (o->controllen < sizeof(cmsghdr)) return nullptr;
+
+    return (cmsghdr *)((unsigned char *)recvmsg_name(o) + msgh->msg_namelen);
+}
+
+static inline cmsghdr *
+recvmsg_cmsg_nexthdr(io_uring_recvmsg_out *o, msghdr *msgh, cmsghdr *cmsg) {
+    unsigned char *end;
+
+    if (cmsg->cmsg_len < sizeof(cmsghdr)) return nullptr;
+    end = (unsigned char *)recvmsg_cmsg_firsthdr(o, msgh) + o->controllen;
+    cmsg = (cmsghdr *)((unsigned char *)cmsg + CMSG_ALIGN(cmsg->cmsg_len));
+
+    if ((unsigned char *)(cmsg + 1) > end) return nullptr;
+    if (((unsigned char *)cmsg) + CMSG_ALIGN(cmsg->cmsg_len) > end)
+        return nullptr;
+
+    return cmsg;
+}
+
+static inline void *recvmsg_payload(io_uring_recvmsg_out *o, msghdr *msgh) {
+    // clang-format off
+    return (void *)((unsigned char *)recvmsg_name(o)
+            + msgh->msg_namelen + msgh->msg_controllen);
+    // clang-format on
+}
+
+static inline unsigned int
+recvmsg_payload_length(io_uring_recvmsg_out *o, int buf_len, msghdr *msgh) {
+    unsigned long payload_start, payload_end;
+
+    payload_start = (unsigned long)recvmsg_payload(o, msgh);
+    payload_end = (unsigned long)o + buf_len;
+    return (unsigned int)(payload_end - payload_start);
+}
+
+} // namespace liburingcxx

--- a/lib/co_context/net/socket.cpp
+++ b/lib/co_context/net/socket.cpp
@@ -40,7 +40,7 @@ socket &socket::set_tcp_no_delay(bool on) {
             static_cast<socklen_t>(sizeof optval)
         )
         < 0) {
-        perror("socket::setTcpNoDelay");
+        perror("socket::set_tcp_no_delay");
     }
     return *this;
 }
@@ -50,7 +50,7 @@ inet_address socket::get_local_addr() const {
     socklen_t addrlen = sizeof localaddr;
     struct sockaddr *addr = reinterpret_cast<struct sockaddr *>(&localaddr);
     if (::getsockname(sockfd, addr, &addrlen) < 0) {
-        perror("socket::getLocalAddr");
+        perror("socket::get_local_addr");
     }
     return inet_address(*addr);
 }
@@ -60,7 +60,7 @@ inet_address socket::get_peer_addr() const {
     socklen_t addrlen = sizeof peeraddr;
     struct sockaddr *addr = reinterpret_cast<struct sockaddr *>(&peeraddr);
     if (::getpeername(sockfd, addr, &addrlen) < 0) {
-        perror("socket::getPeerAddr");
+        perror("socket::get_peer_addr");
     }
     return inet_address(*addr);
 }

--- a/test/cat.cpp
+++ b/test/cat.cpp
@@ -67,7 +67,7 @@ void submit_read_request(uring &ring, const std::filesystem::path path) {
 
     // submit the read request
     liburingcxx::sq_entry &sqe = *ring.get_sq_entry();
-    sqe.prepare_readv(file_fd, std::span{fi->iovecs, blocks}, 0)
+    sqe.prep_readv(file_fd, std::span{fi->iovecs, blocks}, 0)
         .set_data(reinterpret_cast<uint64_t>(fi));
 
     // Must be called after any request (except for polling mode)

--- a/test/coro_lifetime.cpp
+++ b/test/coro_lifetime.cpp
@@ -1,0 +1,27 @@
+#include "co_context/all.hpp"
+using namespace co_context;
+
+struct S {
+    int x;
+
+    S(int x) : x(x) { printf("S(%d)\n", x); }
+
+    S(const S &s) : x(s.x * 10) { printf("S(copy S(%d)) -> %d\n", s.x, x); }
+
+    S(S &&s) : x(s.x * 10) { printf("S(move S(%d)) -> %d\n", s.x, x); }
+
+    ~S() { printf("~S(%d)\n", x); }
+};
+
+task<> coro(S s) {
+    printf("coro running\n");
+    printf("coro finished\n");
+    co_return;
+}
+
+int main() {
+    io_context ctx;
+    ctx.co_spawn(coro(S{1}));
+    ctx.run();
+    return 0;
+}

--- a/test/ctx_swtch.cpp
+++ b/test/ctx_swtch.cpp
@@ -10,8 +10,8 @@ uint32_t count = 0;
 task<> run() {
     auto start = std::chrono::steady_clock::now();
 
-    while (++count < total_switch) [[likely]]
-        co_await lazy::yield();
+    while (++count < total_switch)
+        [[likely]] co_await lazy::yield();
 
     if (count == total_switch) [[unlikely]] {
         auto end = std::chrono::steady_clock::now();

--- a/test/generator_test.cpp
+++ b/test/generator_test.cpp
@@ -10,6 +10,8 @@
 #include <tuple>
 #include <vector>
 
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+
 namespace {
 ///////////////////////
 // Simple non-nested serial generator

--- a/test/httpd.cpp
+++ b/test/httpd.cpp
@@ -176,7 +176,7 @@ int add_accept_request(
     socklen_t *client_addr_len
 ) {
     auto &sqe = *ring.get_sq_entry();
-    sqe.prepare_accept(
+    sqe.prep_accept(
         server_socket, reinterpret_cast<sockaddr *>(client_addr),
         client_addr_len, 0
     );
@@ -200,7 +200,7 @@ int add_read_request(int client_socket) {
     req->client_socket = client_socket;
     std::memset(req->iov[0].iov_base, 0, READ_SZ);
     /* Linux kernel 5.5 has support for readv, but not for recv() or read() */
-    sqe.prepare_readv(client_socket, {req->iov, 1}, 0);
+    sqe.prep_readv(client_socket, {req->iov, 1}, 0);
     sqe.set_data((uint64_t)req);
     ring.append_sq_entry(&sqe);
     ring.submit();
@@ -210,7 +210,7 @@ int add_read_request(int client_socket) {
 int add_write_request(struct request *req) {
     auto &sqe = *ring.get_sq_entry();
     req->event_type = EVENT_TYPE_WRITE;
-    sqe.prepare_writev(req->client_socket, {req->iov, req->iovec_count}, 0);
+    sqe.prep_writev(req->client_socket, {req->iov, req->iovec_count}, 0);
     sqe.set_data((uint64_t)req);
     ring.append_sq_entry(&sqe);
     ring.submit();

--- a/test/nc_uring.cpp
+++ b/test/nc_uring.cpp
@@ -26,7 +26,7 @@ void handle_recv() {
 void handle_peer() {
     peer = res;
     auto sqe = ring.get_sq_entry();
-    sqe->prepare_recv(peer, recv_buf, 0);
+    sqe->prep_recv(peer, recv_buf, 0);
     sqe->set_data((uintptr_t)handle_recv);
     ring.append_sq_entry(sqe);
     ring.submit();
@@ -50,7 +50,7 @@ void event_loop() {
 void server(uint16_t port) {
     acceptor ac{inet_address{port}};
     auto sqe = ring.get_sq_entry();
-    sqe->prepare_accept(ac.listen_fd(), nullptr, nullptr, 0);
+    sqe->prep_accept(ac.listen_fd(), nullptr, nullptr, 0);
     sqe->set_data((uintptr_t)handle_peer);
     ring.append_sq_entry(sqe);
     ring.submit();
@@ -64,7 +64,7 @@ void client(std::string_view hostname, uint16_t port) {
         co_context::socket sock{co_context::socket::create_tcp(addr.family())};
         // 连接一个 server
         auto sqe = ring.get_sq_entry();
-        sqe->prepare_connect(sock.fd(), addr.get_sockaddr(), addr.length());
+        sqe->prep_connect(sock.fd(), addr.get_sockaddr(), addr.length());
         sqe->set_data((uintptr_t)handle_peer);
         ring.append_sq_entry(sqe);
         ring.submit();

--- a/test/photon_streaming_client.cpp
+++ b/test/photon_streaming_client.cpp
@@ -6,7 +6,6 @@ using Socket = co_context::socket;
 constexpr std::string_view hostname{"127.0.0.1"};
 constexpr uint16_t port = 9527;
 constexpr size_t buf_size = 512;
-constexpr int connection_num = 100;
 
 task<> recv_session(Socket sock) {
     char buf[buf_size];

--- a/test/swtch.cpp
+++ b/test/swtch.cpp
@@ -37,7 +37,7 @@ int main() {
     to[0].target = tasks[1].get_handle();
     to[1].target = tasks[0].get_handle();
 
-    auto duration = hostTiming([&] { tasks[0].get_handle().resume(); });
+    auto duration = host_timing([&] { tasks[0].get_handle().resume(); });
 
     printf(
         "Avg. coro switch time = %3.3f ns.\n",


### PR DESCRIPTION
- We introduce full supported SQE operations from [liburing](https://github.com/axboe/liburing), 74 syscalls in total. (`lazy_io` will support these 74 syscalls soon.)

- A hidden bug in co_spawned task is found and fixed. It once caused that the parameters of `task<void>` could not be deconstructed correctly