### PR TITLE
Fix exception handling in detached task; Lint with clang-tidy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,6 +40,7 @@ Cpp11BracedListStyle: true
 EmptyLineBeforeAccessModifier: Always
 FixNamespaceComments: true
 IndentCaseLabels: true
+InsertBraces: true
 IndentExternBlock: Indent
 IndentGotoLabels: true
 IndentPPDirectives: None

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ _deps
 # clangd
 .cache/
 
+# clang-tidy
+.clang-tidy
+
 # Built Visual Studio Code Extensions
 *.vsix
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
     "files.associations": {
         ".clang-format": "yaml",
         "*.clang-format": "yaml",
+        ".clang-tidy": "yaml",
+        "*.clang-tidy": "yaml",
         "*.cu": "cpp",
         "io_uring.h": "c",
         "syscall.h": "c",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
         "*.clang-format": "yaml",
         ".clang-tidy": "yaml",
         "*.clang-tidy": "yaml",
+        "*.cppx": "cpp",
         "*.cu": "cpp",
         "io_uring.h": "c",
         "syscall.h": "c",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ if (NOT CMAKE_BUILD_TYPE)
     message("Setting default CMAKE_BUILD_TYPE to Release")
 endif()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 project(co_context VERSION 0.5.0 LANGUAGES C CXX)
 
 if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")

--- a/example/cv_notify_all.cpp
+++ b/example/cv_notify_all.cpp
@@ -1,9 +1,9 @@
+#include "co_context/all.hpp"
 #include <array>
 #include <cstddef>
 #include <iomanip>
 #include <iostream>
 #include <random>
-#include "co_context/all.hpp"
 
 co_context::condition_variable cv;
 co_context::mutex cv_m; // This mutex is used for three purposes:

--- a/example/cv_notify_one.cpp
+++ b/example/cv_notify_one.cpp
@@ -1,13 +1,13 @@
+#include "co_context/co/mutex.hpp"
+#include "co_context/co/condition_variable.hpp"
+#include "co_context/io_context.hpp"
+#include "co_context/task.hpp"
 #include <array>
 #include <chrono>
 #include <cstddef>
 #include <iomanip>
 #include <iostream>
-#include "co_context/co/mutex.hpp"
 #include <random>
-#include "co_context/co/condition_variable.hpp"
-#include "co_context/io_context.hpp"
-#include "co_context/task.hpp"
 
 using namespace co_context;
 using namespace std::literals;

--- a/example/echo_server_asio.cppx
+++ b/example/echo_server_asio.cppx
@@ -1,8 +1,8 @@
+#include <boost/asio.hpp>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <utility>
-#include <boost/asio.hpp>
 
 using boost::asio::ip::tcp;
 

--- a/example/iota.cpp
+++ b/example/iota.cpp
@@ -4,8 +4,9 @@
 #include <ranges>
 
 co_context::generator<int> gen_iota(int x) {
-    while (true)
+    while (true) {
         co_yield x++;
+    }
 }
 
 int main() {

--- a/example/mtx.cpp
+++ b/example/mtx.cpp
@@ -8,14 +8,16 @@ int cnt = 0;
 
 task<> add() {
     auto lock = co_await mtx.lock_guard();
-    for (int i = 0; i < 1000000; ++i)
+    for (int i = 0; i < 1000000; ++i) {
         ++cnt;
+    }
     std::cout << cnt << std::endl;
 }
 
 int main() {
     io_context ctx;
-    for (int i = 0; i < 1000; ++i)
+    for (int i = 0; i < 1000; ++i) {
         ctx.co_spawn(add());
+    }
     ctx.run();
 }

--- a/example/netcat_timeout.cpp
+++ b/example/netcat_timeout.cpp
@@ -25,7 +25,9 @@ task<> session(Socket sock) {
         nr = co_await timeout(sock.recv(buf), 3s);
     }
 
-    if (nr < 0) log_error(-nr);
+    if (nr < 0) {
+        log_error(-nr);
+    }
 }
 
 task<> server(uint16_t port) {

--- a/example/sem.cpp
+++ b/example/sem.cpp
@@ -1,14 +1,14 @@
+#include "co_context/co/mutex.hpp"
+#include "co_context/co/semaphore.hpp"
+#include "co_context/io_context.hpp"
+#include "co_context/lazy_io.hpp"
+#include "co_context/task.hpp"
 #include <array>
 #include <chrono>
 #include <cstddef>
 #include <iomanip>
 #include <iostream>
 #include <random>
-#include "co_context/co/mutex.hpp"
-#include "co_context/co/semaphore.hpp"
-#include "co_context/io_context.hpp"
-#include "co_context/task.hpp"
-#include "co_context/lazy_io.hpp"
 
 using namespace co_context;
 using namespace std::literals;

--- a/include/co_context/all.hpp
+++ b/include/co_context/all.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "./net.hpp"
-#include "./generator.hpp"
+#include "./co/channel.hpp"
 #include "./co/condition_variable.hpp"
 #include "./co/mutex.hpp"
 #include "./co/semaphore.hpp"
-#include "./co/channel.hpp"
+#include "./generator.hpp"
 #include "./utility/buffer.hpp"
 #include "./utility/defer.hpp"
 #include "./utility/polymorphism.hpp"

--- a/include/co_context/co/mutex.hpp
+++ b/include/co_context/co/mutex.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <coroutine>
-#include <atomic>
 #include "co_context/detail/task_info.hpp"
+#include <atomic>
 #include <cassert>
+#include <coroutine>
 
 namespace co_context {
 
@@ -20,7 +20,7 @@ class mutex final {
         explicit lock_awaiter(mutex & mtx) noexcept : mtx(mtx) {
         }
 
-        constexpr bool await_ready() const noexcept {
+        static constexpr bool await_ready() noexcept {
             return false;
         }
 
@@ -110,7 +110,7 @@ class mutex final {
     /**
      * @brief Construct a new mutex that is not locked.
      */
-    mutex() noexcept : awaiting(not_locked), to_resume(nullptr) {}
+    mutex() noexcept : awaiting(not_locked) {}
 
     /**
      * @brief Destroy the mutex.
@@ -155,7 +155,7 @@ class mutex final {
     inline static constexpr std::uintptr_t not_locked = 1;
 
     std::atomic<std::uintptr_t> awaiting;
-    lock_awaiter *to_resume;
+    lock_awaiter *to_resume = nullptr;
 };
 
 } // namespace co_context

--- a/include/co_context/co/semaphore.hpp
+++ b/include/co_context/co/semaphore.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <type_traits>
 #include "co_context/detail/task_info.hpp"
 #include "co_context/utility/as_atomic.hpp"
+#include <type_traits>
 
 namespace co_context {
 
@@ -18,7 +18,7 @@ class counting_semaphore final {
         }
 
         bool await_ready() noexcept {
-            T old_counter =
+            const T old_counter =
                 sem.counter.fetch_sub(1, std::memory_order_acquire); // seq_cst?
             return old_counter > 0;
         }
@@ -38,7 +38,7 @@ class counting_semaphore final {
   public:
     explicit counting_semaphore(T desired) noexcept
         : awaiting(nullptr)
-        , to_resume(nullptr)
+
         , counter(desired)
         , awaken_task(task_info::task_type::semaphore_release) {
         // awaken_task.sem = this; // deprecated
@@ -64,7 +64,7 @@ class counting_semaphore final {
 
   private:
     std::atomic<acquire_awaiter *> awaiting;
-    acquire_awaiter *to_resume;
+    acquire_awaiter *to_resume = nullptr;
     std::atomic<T> counter;
 
     task_info awaken_task;

--- a/include/co_context/config.hpp
+++ b/include/co_context/config.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
-// #include <new>
-#include <cstddef>
-#include <cstdint>
 #include "uring/io_uring.h"
 #include <bit>
+#include <cstddef>
+#include <cstdint>
 
 namespace co_context {
 

--- a/include/co_context/config.hpp
+++ b/include/co_context/config.hpp
@@ -41,14 +41,15 @@ namespace config {
 
     using tid_t = tid_size_t;
 
-    inline constexpr bool using_hyper_threading = true;
+    inline constexpr bool is_using_hyper_threading = true;
 
     /**
      * @brief This tells if a standalone thread will run in kernel space.
      *
      * @note Do not modify this, check `io_uring_flags` instead.
      */
-    inline constexpr bool using_SQPOLL = io_uring_flags & IORING_SETUP_SQPOLL;
+    inline constexpr bool is_using_sqpoll =
+        bool(io_uring_flags & IORING_SETUP_SQPOLL);
 
     /**
      * @brief This number tells how many standalone worker-threads are running
@@ -70,15 +71,15 @@ namespace config {
     inline constexpr tid_size_t workers_number =
         worker_threads_number > 1 ? worker_threads_number : 1;
 
-    inline constexpr bool use_standalone_completion_poller = false;
+    inline constexpr bool is_using_standalone_completion_poller = false;
     static_assert(
-        !use_standalone_completion_poller || worker_threads_number > 0
+        !is_using_standalone_completion_poller || worker_threads_number > 0
     );
     // ========================================================================
 
     // ======================= io_context configuration =======================
     // Enabling this would significantly increase latency in multi-thread model.
-    inline constexpr bool use_wait_and_notify = true;
+    inline constexpr bool is_using_wait_and_notify = true;
 
     using swap_capacity_size_t = uint16_t;
     using cur_t = swap_capacity_size_t;
@@ -109,8 +110,8 @@ namespace config {
     // ========================================================================
 
     // ========================== net configuration ===========================
-    inline constexpr bool loopback_only = true;
-    // inline constexpr bool loopback_only = false;
+    inline constexpr bool is_loopback_only = true;
+    // inline constexpr bool is_loopback_only = false;
     // ========================================================================
 
     // =========================== co configuration ===========================

--- a/include/co_context/detail/lazy_io_awaiter.hpp
+++ b/include/co_context/detail/lazy_io_awaiter.hpp
@@ -161,9 +161,9 @@ namespace detail {
 
     struct lazy_read_fixed : lazy_awaiter {
         inline lazy_read_fixed(
-            int fd, std::span<char> buf, uint64_t offset, uint16_t bufIndex
+            int fd, std::span<char> buf, uint64_t offset, uint16_t buf_index
         ) noexcept {
-            sqe->prep_read_fixed(fd, buf, offset, bufIndex);
+            sqe->prep_read_fixed(fd, buf, offset, buf_index);
         }
     };
 
@@ -188,9 +188,9 @@ namespace detail {
             int fd,
             std::span<const char> buf,
             uint64_t offset,
-            uint16_t bufIndex
+            uint16_t buf_index
         ) noexcept {
-            sqe->prep_write_fixed(fd, buf, offset, bufIndex);
+            sqe->prep_write_fixed(fd, buf, offset, buf_index);
         }
     };
 

--- a/include/co_context/detail/lazy_io_awaiter.hpp
+++ b/include/co_context/detail/lazy_io_awaiter.hpp
@@ -34,7 +34,7 @@ namespace detail {
         int32_t await_resume() const noexcept { return io_info.result; }
 
       protected:
-        friend class lazy_link_io;
+        friend struct lazy_link_io;
         friend struct lazy_link_timeout;
         liburingcxx::sq_entry *sqe;
         task_info io_info;

--- a/include/co_context/detail/reap_info.hpp
+++ b/include/co_context/detail/reap_info.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <co_context/utility/bit.hpp>
 #include <coroutine>
 #include <cstdint>
-#include <co_context/utility/bit.hpp>
 
 namespace liburingcxx {
 

--- a/include/co_context/detail/swap_zone.hpp
+++ b/include/co_context/detail/swap_zone.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 // #include <concepts>
-#include <type_traits>
-#include <atomic>
 #include "co_context/config.hpp"
+#include "co_context/lockfree/spsc_cursor.hpp"
 #include "co_context/utility/as_atomic.hpp"
 #include "co_context/utility/bit.hpp"
-#include "co_context/lockfree/spsc_cursor.hpp"
+#include <atomic>
 #include <cstring>
+#include <type_traits>
 
 namespace co_context {
 

--- a/include/co_context/detail/task_info.hpp
+++ b/include/co_context/detail/task_info.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include <coroutine>
 #include "co_context/config.hpp"
+#include <coroutine>
 
 #include "co_context/log/log.hpp"
 

--- a/include/co_context/detail/thread_meta.hpp
+++ b/include/co_context/detail/thread_meta.hpp
@@ -8,7 +8,7 @@ class io_context;
 
 namespace detail {
 
-    class worker_meta;
+    struct worker_meta;
 
     struct alignas(config::cache_line_size) thread_meta {
         io_context *ctx;

--- a/include/co_context/detail/worker_meta.hpp
+++ b/include/co_context/detail/worker_meta.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
 #include "co_context/config.hpp"
-#include "co_context/detail/swap_zone.hpp"
-#include "co_context/detail/submit_info.hpp"
 #include "co_context/detail/reap_info.hpp"
+#include "co_context/detail/submit_info.hpp"
+#include "co_context/detail/swap_zone.hpp"
 #include "co_context/detail/thread_meta.hpp"
-#include "co_context/task.hpp"
 #include "co_context/log/log.hpp"
-#include <thread>
+#include "co_context/task.hpp"
 #include <queue>
+#include <thread>
 
 namespace co_context {
 
@@ -17,8 +17,11 @@ class io_context;
 namespace detail {
 
     struct worker_meta final {
-        enum class [[deprecated]] worker_state : uint8_t{
-            running, idle, blocked};
+        enum class [[deprecated]] worker_state : uint8_t {
+            running,
+            idle,
+            blocked
+        };
 
         using cur_t = config::cur_t;
 
@@ -65,20 +68,20 @@ namespace detail {
 
         std::coroutine_handle<> schedule() noexcept;
 
-        cur_t number_to_schedule_relaxed() noexcept {
+        cur_t number_to_schedule_relaxed() const noexcept {
             const auto &cur = this->sharing.reap_cur;
             return cur.size();
         }
 
         std::coroutine_handle<> try_schedule() noexcept;
 
-        void init(const int thread_index, io_context *const context);
+        void init(int thread_index, io_context *context);
 
         void co_spawn(task<void> &&entrance) noexcept;
 
         void co_spawn(std::coroutine_handle<> entrance) noexcept;
 
-        void worker_run_loop(const int thread_index, io_context *const context);
+        void worker_run_loop(int thread_index, io_context *context);
 
         void worker_run_once();
     };

--- a/include/co_context/eager_io.hpp
+++ b/include/co_context/eager_io.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
 #include "uring/uring.hpp"
+#include "co_context/detail/eager_io_state.hpp"
 #include "co_context/detail/task_info.hpp"
 #include "co_context/detail/thread_meta.hpp"
 #include "co_context/detail/worker_meta.hpp"
 #include "co_context/utility/as_atomic.hpp"
-#include "co_context/detail/eager_io_state.hpp"
-// #include "co_context/detail/sqe_task_meta.hpp" // deprecated
-#include <span>
 #include <memory>
+#include <span>
 
 namespace co_context {
 

--- a/include/co_context/eager_io.hpp
+++ b/include/co_context/eager_io.hpp
@@ -122,9 +122,9 @@ namespace detail {
 
     struct eager_read_fixed : eager_awaiter {
         inline eager_read_fixed(
-            int fd, std::span<char> buf, uint64_t offset, uint16_t bufIndex
+            int fd, std::span<char> buf, uint64_t offset, uint16_t buf_index
         ) noexcept {
-            sqe->prep_read_fixed(fd, buf, offset, bufIndex);
+            sqe->prep_read_fixed(fd, buf, offset, buf_index);
             submit();
         }
     };
@@ -152,9 +152,9 @@ namespace detail {
             int fd,
             std::span<const char> buf,
             uint64_t offset,
-            uint16_t bufIndex
+            uint16_t buf_index
         ) noexcept {
-            sqe->prep_write_fixed(fd, buf, offset, bufIndex);
+            sqe->prep_write_fixed(fd, buf, offset, buf_index);
             submit();
         }
     };
@@ -458,9 +458,9 @@ namespace eager {
     }
 
     inline detail::eager_read_fixed read_fixed(
-        int fd, std::span<char> buf, uint64_t offset, uint16_t bufIndex
+        int fd, std::span<char> buf, uint64_t offset, uint16_t buf_index
     ) noexcept {
-        return detail::eager_read_fixed{fd, buf, offset, bufIndex};
+        return detail::eager_read_fixed{fd, buf, offset, buf_index};
     }
 
     inline detail::eager_write
@@ -474,9 +474,9 @@ namespace eager {
     }
 
     inline detail::eager_write_fixed write_fixed(
-        int fd, std::span<const char> buf, uint64_t offset, uint16_t bufIndex
+        int fd, std::span<const char> buf, uint64_t offset, uint16_t buf_index
     ) noexcept {
-        return detail::eager_write_fixed{fd, buf, offset, bufIndex};
+        return detail::eager_write_fixed{fd, buf, offset, buf_index};
     }
 
     inline detail::eager_accept

--- a/include/co_context/io_context.hpp
+++ b/include/co_context/io_context.hpp
@@ -18,18 +18,17 @@
  */
 #pragma once
 
-#include <linux/version.h>
-#include <thread>
-#include <vector>
-#include <queue>
 #include "uring/uring.hpp"
 #include "co_context/config.hpp"
-#include "co_context/detail/task_info.hpp"
-#include "co_context/detail/submit_info.hpp"
 #include "co_context/detail/reap_info.hpp"
-#include "co_context/task.hpp"
+#include "co_context/detail/submit_info.hpp"
+#include "co_context/detail/task_info.hpp"
 #include "co_context/detail/thread_meta.hpp"
 #include "co_context/detail/worker_meta.hpp"
+#include "co_context/task.hpp"
+#include <queue>
+#include <thread>
+#include <vector>
 
 namespace co_context {
 
@@ -53,7 +52,7 @@ class [[nodiscard]] io_context final {
 
     using task_info = detail::task_info;
 
-    friend class detail::worker_meta;
+    friend struct detail::worker_meta;
     using worker_meta = detail::worker_meta;
 
   private:

--- a/include/co_context/io_context.hpp
+++ b/include/co_context/io_context.hpp
@@ -114,8 +114,9 @@ class [[nodiscard]] io_context final {
      * @brief `cur = (cur + 1) % workers_number`
      */
     inline static void cur_next(config::tid_t &cur) noexcept {
-        if constexpr (config::workers_number > 1)
+        if constexpr (config::workers_number > 1) {
             cur = (cur + 1) % config::workers_number;
+        }
     }
 
   private:
@@ -246,7 +247,9 @@ class [[nodiscard]] io_context final {
     ~io_context() noexcept {
         for (int i = 0; i < config::worker_threads_number; ++i) {
             std::thread &t = worker[i].host_thread;
-            if (t.joinable()) t.join();
+            if (t.joinable()) {
+                t.join();
+            }
         }
     }
 
@@ -260,10 +263,11 @@ class [[nodiscard]] io_context final {
 };
 
 inline void co_spawn(task<void> &&entrance) noexcept {
-    if (detail::this_thread.worker != nullptr) [[likely]]
+    if (detail::this_thread.worker != nullptr) [[likely]] {
         detail::this_thread.worker->co_spawn(entrance.get_handle());
-    else
+    } else {
         detail::this_thread.ctx->co_spawn(entrance.get_handle());
+    }
     entrance.detach();
 }
 

--- a/include/co_context/lazy_io.hpp
+++ b/include/co_context/lazy_io.hpp
@@ -463,7 +463,7 @@ inline namespace lazy {
 
     [[nodiscard("Did you forget to co_await?")]] inline detail::lazy_link
     link(const char *oldpath, const char *newpath, int flags) noexcept {
-        return detail::lazy_link{oldpath, oldpath, flags};
+        return detail::lazy_link{oldpath, newpath, flags};
     }
 
     [[nodiscard("Did you forget to co_await?")]] inline detail::lazy_msg_ring

--- a/include/co_context/lazy_io.hpp
+++ b/include/co_context/lazy_io.hpp
@@ -62,9 +62,9 @@ inline namespace lazy {
 
     [[nodiscard("Did you forget to co_await?")]] inline detail::lazy_read_fixed
     read_fixed(
-        int fd, std::span<char> buf, uint64_t offset, uint16_t bufIndex
+        int fd, std::span<char> buf, uint64_t offset, uint16_t buf_index
     ) noexcept {
-        return detail::lazy_read_fixed{fd, buf, offset, bufIndex};
+        return detail::lazy_read_fixed{fd, buf, offset, buf_index};
     }
 
     [[nodiscard("Did you forget to co_await?")]] inline detail::lazy_writev
@@ -76,9 +76,9 @@ inline namespace lazy {
 
     [[nodiscard("Did you forget to co_await?")]] inline detail::lazy_write_fixed
     write_fixed(
-        int fd, std::span<const char> buf, uint64_t offset, uint16_t bufIndex
+        int fd, std::span<const char> buf, uint64_t offset, uint16_t buf_index
     ) noexcept {
-        return detail::lazy_write_fixed{fd, buf, offset, bufIndex};
+        return detail::lazy_write_fixed{fd, buf, offset, buf_index};
     }
 
     [[nodiscard("Did you forget to co_await?")]] inline detail::lazy_recvmsg

--- a/include/co_context/lockfree/spsc_cursor.hpp
+++ b/include/co_context/lockfree/spsc_cursor.hpp
@@ -110,7 +110,7 @@ struct spsc_cursor {
             assert(head_full != load_raw_head());
             return;
         }
-        if constexpr (config::use_wait_and_notify) {
+        if constexpr (config::is_using_wait_and_notify) {
             as_c_atomic(m_head).wait(head_full, std::memory_order_acquire);
         } else {
             while (head_full == load_raw_head()) {}
@@ -123,7 +123,7 @@ struct spsc_cursor {
             assert(tail_empty != load_raw_tail());
             return;
         }
-        if constexpr (config::use_wait_and_notify) {
+        if constexpr (config::is_using_wait_and_notify) {
             as_c_atomic(m_tail).wait(tail_empty, std::memory_order_acquire);
         } else {
             while (tail_empty == load_raw_tail()) {}
@@ -148,14 +148,14 @@ struct spsc_cursor {
 
     inline void push_notify(T num = 1) noexcept {
         push(num);
-        if constexpr (need_thread_safe && config::use_wait_and_notify) {
+        if constexpr (need_thread_safe && config::is_using_wait_and_notify) {
             as_atomic(m_tail).notify_one();
         }
     }
 
     inline void pop_notify(T num = 1) noexcept {
         pop(num);
-        if constexpr (need_thread_safe && config::use_wait_and_notify) {
+        if constexpr (need_thread_safe && config::is_using_wait_and_notify) {
             as_atomic(m_head).notify_one();
         }
     }

--- a/include/co_context/lockfree/spsc_cursor.hpp
+++ b/include/co_context/lockfree/spsc_cursor.hpp
@@ -39,47 +39,53 @@ struct spsc_cursor {
     }
 
     inline T load_head() const noexcept {
-        if constexpr (need_thread_safe)
+        if constexpr (need_thread_safe) {
             return as_c_atomic(m_head).load(std::memory_order_acquire) & mask;
-        else
+        } else {
             return head();
+        }
     }
 
     inline T load_tail() const noexcept {
-        if constexpr (need_thread_safe)
+        if constexpr (need_thread_safe) {
             return as_c_atomic(m_tail).load(std::memory_order_acquire) & mask;
-        else
+        } else {
             return tail();
+        }
     }
 
     inline T load_raw_head() const noexcept {
-        if constexpr (need_thread_safe)
+        if constexpr (need_thread_safe) {
             return as_c_atomic(m_head).load(std::memory_order_acquire);
-        else
+        } else {
             return raw_head();
+        }
     }
 
     inline T load_raw_tail() const noexcept {
-        if constexpr (need_thread_safe)
+        if constexpr (need_thread_safe) {
             return as_c_atomic(m_tail).load(std::memory_order_acquire);
-        else
+        } else {
             return raw_tail();
+        }
     }
 
     inline T load_raw_tail_relaxed() const noexcept {
-        if constexpr (need_thread_safe)
+        if constexpr (need_thread_safe) {
             return as_c_atomic(m_tail).load(std::memory_order_relaxed);
-        else
+        } else {
             return raw_tail();
+        }
     }
 
     // inline void set_raw_tail(T tail) const noexcept { m_tail = tail; }
 
     inline void store_raw_tail(T tail) noexcept {
-        if constexpr (need_thread_safe)
+        if constexpr (need_thread_safe) {
             as_atomic(m_tail).store(tail, std::memory_order_release);
-        else
+        } else {
             m_tail = tail;
+        }
     }
 
     inline bool is_empty_load_head() const noexcept {
@@ -125,29 +131,33 @@ struct spsc_cursor {
     }
 
     inline void push(T num = 1) noexcept {
-        if constexpr (need_thread_safe)
+        if constexpr (need_thread_safe) {
             as_atomic(m_tail).store(m_tail + num, std::memory_order_release);
-        else
+        } else {
             m_tail += num;
+        }
     }
 
     inline void pop(T num = 1) noexcept {
-        if constexpr (need_thread_safe)
+        if constexpr (need_thread_safe) {
             as_atomic(m_head).store(m_head + num, std::memory_order_release);
-        else
+        } else {
             m_head += num;
+        }
     }
 
     inline void push_notify(T num = 1) noexcept {
         push(num);
-        if constexpr (need_thread_safe && config::use_wait_and_notify)
+        if constexpr (need_thread_safe && config::use_wait_and_notify) {
             as_atomic(m_tail).notify_one();
+        }
     }
 
     inline void pop_notify(T num = 1) noexcept {
         pop(num);
-        if constexpr (need_thread_safe && config::use_wait_and_notify)
+        if constexpr (need_thread_safe && config::use_wait_and_notify) {
             as_atomic(m_head).notify_one();
+        }
     }
 };
 

--- a/include/co_context/lockfree/spsc_cursor.hpp
+++ b/include/co_context/lockfree/spsc_cursor.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <co_context/utility/bit.hpp>
-#include <co_context/utility/as_atomic.hpp>
 #include <co_context/config.hpp>
+#include <co_context/utility/as_atomic.hpp>
+#include <co_context/utility/bit.hpp>
 
 namespace co_context {
 

--- a/include/co_context/log/log.hpp
+++ b/include/co_context/log/log.hpp
@@ -27,32 +27,37 @@ namespace detail {
 namespace log {
     template<typename... T>
     void v(const char *__restrict__ fmt, const T &...args) {
-        if constexpr (config::log_level <= config::level::verbose)
+        if constexpr (config::log_level <= config::level::verbose) {
             detail::log(fmt, args...);
+        }
     }
 
     template<typename... T>
     void i(const char *__restrict__ fmt, const T &...args) {
-        if constexpr (config::log_level <= config::level::info)
+        if constexpr (config::log_level <= config::level::info) {
             detail::log(fmt, args...);
+        }
     }
 
     template<typename... T>
     void d(const char *__restrict__ fmt, const T &...args) {
-        if constexpr (config::log_level <= config::level::debug)
+        if constexpr (config::log_level <= config::level::debug) {
             detail::log(fmt, args...);
+        }
     }
 
     template<typename... T>
     void w(const char *__restrict__ fmt, const T &...args) {
-        if constexpr (config::log_level <= config::level::warning)
+        if constexpr (config::log_level <= config::level::warning) {
             detail::err(fmt, args...);
+        }
     }
 
     template<typename... T>
     void e(const char *__restrict__ fmt, const T &...args) {
-        if constexpr (config::log_level <= config::level::error)
+        if constexpr (config::log_level <= config::level::error) {
             detail::err(fmt, args...);
+        }
     }
 } // namespace log
 

--- a/include/co_context/net/acceptor.hpp
+++ b/include/co_context/net/acceptor.hpp
@@ -31,7 +31,7 @@ class acceptor {
     socket listen_socket;
 };
 
-acceptor::acceptor(const inet_address &listen_addr)
+inline acceptor::acceptor(const inet_address &listen_addr)
     : listen_socket(socket::create_tcp(listen_addr.family())) {
     listen_socket.set_reuse_addr(true).bind(listen_addr).listen();
 }

--- a/include/co_context/net/inet_address.hpp
+++ b/include/co_context/net/inet_address.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <netinet/in.h>
+#include "co_context/utility/defer.hpp"
+#include "co_context/config.hpp"
 #include <netdb.h>
+#include <netinet/in.h>
 #include <string>
 #include <string_view>
 #include <vector>
-#include "co_context/utility/defer.hpp"
-#include "co_context/config.hpp"
 
 namespace co_context {
 
@@ -25,7 +25,7 @@ class inet_address {
     /**
      * @brief for listening
      */
-    inet_address(uint16_t port, bool isIpv6 = false) noexcept;
+    inet_address(uint16_t port, bool is_ipv6 = false) noexcept;
 
     /**
      * @brief for Sockets API

--- a/include/co_context/net/socket.hpp
+++ b/include/co_context/net/socket.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
-#include <unistd.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <sys/socket.h>
-// #include "co_context/utility/defer.hpp"
-// #include "co_context/config.hpp"
 #include "co_context/lazy_io.hpp"
 #include "co_context/eager_io.hpp"
 #include "co_context/net/inet_address.hpp"
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 namespace co_context {
 
@@ -20,15 +18,8 @@ class socket {
         assert(sockfd >= 0);
     };
 
-    ~socket() noexcept {
-        // TODO check ~socket()
-        /*
-        if (sockfd >= 0) {
-            [[maybe_unused]] int res = ::close(sockfd);
-            assert(res == 0);
-        }
-        */
-    };
+    // TODO check if ~socket() need `close(sockfd)`
+    ~socket() noexcept = default;
 
     socket(socket &&other) noexcept {
         sockfd = other.sockfd;
@@ -43,7 +34,7 @@ class socket {
     }
 
     void swap(socket &other) noexcept {
-        int tmp = sockfd;
+        const int tmp = sockfd;
         sockfd = other.sockfd;
         other.sockfd = tmp;
     }
@@ -62,45 +53,47 @@ class socket {
 
     inet_address get_peer_addr() const;
 
-    auto connect(const inet_address &addr) noexcept {
+    auto connect(const inet_address &addr) const noexcept {
         return lazy::connect(sockfd, addr.get_sockaddr(), addr.length());
     }
 
-    auto eager_connect(const inet_address &addr) noexcept {
+    auto eager_connect(const inet_address &addr) const noexcept {
         return eager::connect(sockfd, addr.get_sockaddr(), addr.length());
     }
 
-    auto recv(std::span<char> buf, int flags = 0) noexcept {
+    auto recv(std::span<char> buf, int flags = 0) const noexcept {
         return lazy::recv(sockfd, buf, flags);
     }
 
-    auto eager_recv(std::span<char> buf, int flags = 0) noexcept {
+    auto eager_recv(std::span<char> buf, int flags = 0) const noexcept {
         return eager::recv(sockfd, buf, flags);
     }
 
-    auto send(std::span<const char> buf, int flags = 0) noexcept {
+    auto send(std::span<const char> buf, int flags = 0) const noexcept {
         return lazy::send(sockfd, buf, flags);
     }
 
-    auto eager_send(std::span<const char> buf, int flags = 0) noexcept {
+    auto eager_send(std::span<const char> buf, int flags = 0) const noexcept {
         return eager::send(sockfd, buf, flags);
     }
 
     auto close() noexcept {
-        int tmp = sockfd;
+        const int tmp = sockfd;
         sockfd = -1;
         return lazy::close(tmp);
     }
 
     auto eager_close() noexcept {
-        int tmp = sockfd;
+        const int tmp = sockfd;
         sockfd = -1;
         return eager::close(tmp);
     }
 
-    auto shutdown_write() noexcept { return lazy::shutdown(sockfd, SHUT_WR); }
+    auto shutdown_write() const noexcept {
+        return lazy::shutdown(sockfd, SHUT_WR);
+    }
 
-    auto eager_shutdown_write() noexcept {
+    auto eager_shutdown_write() const noexcept {
         return eager::shutdown(sockfd, SHUT_WR);
     }
 
@@ -113,13 +106,14 @@ class socket {
 };
 
 inline socket socket::create_tcp(sa_family_t family) {
-    int sockfd = ::socket(family, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
+    const int sockfd =
+        ::socket(family, SOCK_STREAM | SOCK_CLOEXEC, IPPROTO_TCP);
     assert(sockfd >= 0);
     return socket{sockfd};
 }
 
 inline socket socket::create_udp(sa_family_t family) {
-    int sockfd = ::socket(family, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
+    const int sockfd = ::socket(family, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
     assert(sockfd >= 0);
     return socket{sockfd};
 }

--- a/include/co_context/task.hpp
+++ b/include/co_context/task.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <coroutine>
-#include <concepts>
 #include <cassert>
+#include <concepts>
+#include <coroutine>
 #include <memory>
 
 namespace co_context {

--- a/include/co_context/task.hpp
+++ b/include/co_context/task.hpp
@@ -52,7 +52,9 @@ namespace detail {
 
             std::coroutine_handle<> continuation = promise.parent_coro;
 
-            if (promise.is_detached_flag == uintptr_t(-1ULL)) current.destroy();
+            if (promise.is_detached_flag == uintptr_t(-1ULL)) {
+                current.destroy();
+            }
 
             return continuation;
         }
@@ -131,16 +133,18 @@ namespace detail {
 
         // get the lvalue ref
         T &result() & {
-            if (state == value_state::exception) [[unlikely]]
+            if (state == value_state::exception) [[unlikely]] {
                 std::rethrow_exception(exception_ptr);
+            }
             assert(state == value_state::value);
             return value;
         }
 
         // get the prvalue
         T &&result() && {
-            if (state == value_state::exception) [[unlikely]]
+            if (state == value_state::exception) [[unlikely]] {
                 std::rethrow_exception(exception_ptr);
+            }
             assert(state == value_state::value);
             return std::move(value);
         }
@@ -172,8 +176,9 @@ namespace detail {
         }
 
         void result() {
-            if (this->exception_ptr) [[unlikely]]
+            if (this->exception_ptr) [[unlikely]] {
                 std::rethrow_exception(this->exception_ptr);
+            }
         }
 
       private:
@@ -199,8 +204,9 @@ namespace detail {
         }
 
         T &result() {
-            if (exception_ptr) [[unlikely]]
+            if (exception_ptr) [[unlikely]] {
                 std::rethrow_exception(exception_ptr);
+            }
             return *value;
         }
 
@@ -252,7 +258,9 @@ class [[nodiscard("Did you forget to co_await?")]] task {
 
     task<> &operator=(task<> &&other) noexcept {
         if (this != std::addressof(other)) [[likely]] {
-            if (handle) handle.destroy();
+            if (handle) {
+                handle.destroy();
+            }
             handle = other.handle;
             other.handle = nullptr;
         }
@@ -261,7 +269,9 @@ class [[nodiscard("Did you forget to co_await?")]] task {
 
     // Free the promise object and coroutine parameters
     ~task() {
-        if (handle) handle.destroy();
+        if (handle) {
+            handle.destroy();
+        }
     }
 
     inline bool is_ready() const noexcept {

--- a/include/co_context/utility/bit.hpp
+++ b/include/co_context/utility/bit.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <concepts>
 #include <bit>
+#include <concepts>
 #include <cstdint>
 
 namespace co_context {

--- a/include/co_context/utility/buffer.hpp
+++ b/include/co_context/utility/buffer.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 // #include <concepts>
-#include <type_traits>
 #include <span>
+#include <type_traits>
 
 namespace co_context {
 

--- a/include/co_context/utility/set_cpu_affinity.hpp
+++ b/include/co_context/utility/set_cpu_affinity.hpp
@@ -18,9 +18,10 @@ namespace detail {
         ::cpu_set_t cpu_set;
         CPU_SET(cpu, &cpu_set);
         int ret = sched_setaffinity(gettid(), sizeof(cpu_set_t), &cpu_set);
-        if (ret != 0) [[unlikely]]
+        if (ret != 0) [[unlikely]] {
             throw std::system_error{
                 errno, std::system_category(), "sched_setaffinity"};
+        }
     }
 
 } // namespace detail

--- a/include/co_context/utility/timing.hpp
+++ b/include/co_context/utility/timing.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <concepts>
 #include <chrono>
+#include <concepts>
 
 template<std::invocable F>
 [[maybe_unused]] auto host_timing(const F &func) {

--- a/include/uring/buf_ring.hpp
+++ b/include/uring/buf_ring.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "uring/io_uring.h"
+#include <cstdint>
 
 namespace liburingcxx {
 

--- a/include/uring/detail/cq.hpp
+++ b/include/uring/detail/cq.hpp
@@ -35,8 +35,9 @@ namespace detail {
             ring_mask = *(unsigned *)((uintptr_t)ring_ptr + off.ring_mask);
             ring_entries =
                 *(unsigned *)((uintptr_t)ring_ptr + off.ring_entries);
-            if (off.flags)
+            if (off.flags) {
                 kflags = (unsigned *)((uintptr_t)ring_ptr + off.flags);
+            }
             koverflow = (unsigned *)((uintptr_t)ring_ptr + off.overflow);
             cqes = (cq_entry *)((uintptr_t)ring_ptr + off.cqes);
         }

--- a/include/uring/detail/sq.hpp
+++ b/include/uring/detail/sq.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <numeric>
+#include "uring/barrier.h"
 #include "uring/sq_entry.hpp"
+#include <cassert>
+#include <numeric>
 
 namespace liburingcxx {
 

--- a/include/uring/sq_entry.hpp
+++ b/include/uring/sq_entry.hpp
@@ -12,6 +12,7 @@
 
 struct __kernel_timespec;
 struct epoll_event;
+struct statx;
 
 namespace liburingcxx {
 

--- a/include/uring/sq_entry.hpp
+++ b/include/uring/sq_entry.hpp
@@ -175,10 +175,10 @@ class sq_entry final : private io_uring_sqe {
     }
 
     inline sq_entry &prep_read_fixed(
-        int fd, std::span<char> buf, uint64_t offset, uint16_t bufIndex
+        int fd, std::span<char> buf, uint64_t offset, uint16_t buf_index
     ) noexcept {
         prep_rw(IORING_OP_READ_FIXED, fd, buf.data(), buf.size(), offset);
-        this->buf_index = bufIndex;
+        this->buf_index = buf_index;
         return *this;
     }
 
@@ -199,10 +199,10 @@ class sq_entry final : private io_uring_sqe {
     }
 
     inline sq_entry &prep_write_fixed(
-        int fd, std::span<const char> buf, uint64_t offset, uint16_t bufIndex
+        int fd, std::span<const char> buf, uint64_t offset, uint16_t buf_index
     ) noexcept {
         prep_rw(IORING_OP_WRITE_FIXED, fd, buf.data(), buf.size(), offset);
-        this->buf_index = bufIndex;
+        this->buf_index = buf_index;
         return *this;
     }
 

--- a/include/uring/sq_entry.hpp
+++ b/include/uring/sq_entry.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
 #include "uring/io_uring.h"
-#include <cstdint>
-#include <cstring>
-#include <span>
-#include <sys/socket.h>
-// #include <sys/uio.h>
-#include <fcntl.h>
 #include "uring/compat.h"
 #include "uring/utility/io_helper.hpp"
 #include "uring/utility/kernel_version.hpp"
+#include <cstdint>
+#include <cstring>
+#include <fcntl.h>
+#include <span>
+#include <sys/socket.h>
 
 struct __kernel_timespec;
 struct epoll_event;

--- a/include/uring/uring.hpp
+++ b/include/uring/uring.hpp
@@ -21,27 +21,27 @@
 #define _XOPEN_SOURCE 500 /* Required for glibc to expose sigset_t */
 #endif
 
-#include <sys/socket.h>
-#include <sys/uio.h>
-#include <sys/stat.h>
-#include <sys/mman.h>
-#include <sched.h>
-#include <linux/swab.h>
-#include <cassert>
-#include <cerrno>
-#include <csignal>
-#include <cinttypes>
-#include <ctime>
-#include <system_error>
 #include "uring/compat.h"
-#include "uring/io_uring.h"
 #include "uring/barrier.h"
-#include "uring/syscall.hpp"
 #include "uring/buf_ring.hpp"
-#include "uring/detail/sq.hpp"
 #include "uring/detail/cq.hpp"
 #include "uring/detail/int_flags.h"
+#include "uring/detail/sq.hpp"
+#include "uring/io_uring.h"
+#include "uring/syscall.hpp"
 #include "uring/utility/kernel_version.hpp"
+#include <cassert>
+#include <cerrno>
+#include <cinttypes>
+#include <csignal>
+#include <ctime>
+#include <linux/swab.h>
+#include <sched.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <system_error>
 
 struct statx;
 

--- a/include/uring/utility/io_helper.hpp
+++ b/include/uring/utility/io_helper.hpp
@@ -10,7 +10,9 @@ static inline io_uring_recvmsg_out *
 recvmsg_validate(std::span<char> buf, msghdr *msgh) noexcept {
     const size_t header =
         msgh->msg_controllen + msgh->msg_namelen + sizeof(io_uring_recvmsg_out);
-    if (buf.size() < header) return nullptr;
+    if (buf.size() < header) {
+        return nullptr;
+    }
     return reinterpret_cast<io_uring_recvmsg_out *>(buf.data());
 }
 
@@ -20,7 +22,9 @@ static inline void *recvmsg_name(io_uring_recvmsg_out *o) {
 
 static inline cmsghdr *
 recvmsg_cmsg_firsthdr(io_uring_recvmsg_out *o, msghdr *msgh) {
-    if (o->controllen < sizeof(cmsghdr)) return nullptr;
+    if (o->controllen < sizeof(cmsghdr)) {
+        return nullptr;
+    }
 
     return (cmsghdr *)((unsigned char *)recvmsg_name(o) + msgh->msg_namelen);
 }
@@ -29,13 +33,18 @@ static inline cmsghdr *
 recvmsg_cmsg_nexthdr(io_uring_recvmsg_out *o, msghdr *msgh, cmsghdr *cmsg) {
     unsigned char *end;
 
-    if (cmsg->cmsg_len < sizeof(cmsghdr)) return nullptr;
+    if (cmsg->cmsg_len < sizeof(cmsghdr)) {
+        return nullptr;
+    }
     end = (unsigned char *)recvmsg_cmsg_firsthdr(o, msgh) + o->controllen;
     cmsg = (cmsghdr *)((unsigned char *)cmsg + CMSG_ALIGN(cmsg->cmsg_len));
 
-    if ((unsigned char *)(cmsg + 1) > end) return nullptr;
-    if (((unsigned char *)cmsg) + CMSG_ALIGN(cmsg->cmsg_len) > end)
+    if ((unsigned char *)(cmsg + 1) > end) {
         return nullptr;
+    }
+    if (((unsigned char *)cmsg) + CMSG_ALIGN(cmsg->cmsg_len) > end) {
+        return nullptr;
+    }
 
     return cmsg;
 }

--- a/include/uring/utility/kernel_version.hpp
+++ b/include/uring/utility/kernel_version.hpp
@@ -11,12 +11,13 @@
 namespace liburingcxx {
 
 consteval bool is_kernel_reach(int major, int patchlevel) noexcept {
-    if (LIBURINGCXX_KERNEL_VERSION_MAJOR != major)
+    if (LIBURINGCXX_KERNEL_VERSION_MAJOR != major) {
         return LIBURINGCXX_KERNEL_VERSION_MAJOR > major;
+    }
     return LIBURINGCXX_KERNEL_VERSION_PATCHLEVEL >= patchlevel;
 }
 
-}
+} // namespace liburingcxx
 
 #define LIBURINGCXX_IS_KERNEL_REACH(major, patchlevel) \
     (LIBURINGCXX_KERNEL_VERSION_MAJOR > major)         \

--- a/lib/co_context/co/mutex.cpp
+++ b/lib/co_context/co/mutex.cpp
@@ -45,7 +45,7 @@ void mutex::unlock() noexcept {
 
         assert(top != not_locked && top != locked_no_awaiting);
 
-        lock_awaiter *node = reinterpret_cast<lock_awaiter *>(top);
+        auto *node = reinterpret_cast<lock_awaiter *>(top);
         do {
             lock_awaiter *tmp = node->next;
             node->next = resume_head;

--- a/lib/co_context/co/mutex.cpp
+++ b/lib/co_context/co/mutex.cpp
@@ -35,8 +35,9 @@ void mutex::unlock() noexcept {
         if (awaiting.compare_exchange_strong(
                 desire, not_locked, std::memory_order_release,
                 std::memory_order_relaxed
-            ))
+            )) {
             return; // no awaiting -> not locked & return
+        }
 
         // There must be something awaiting now.
         auto top =

--- a/lib/co_context/co/semaphore.cpp
+++ b/lib/co_context/co/semaphore.cpp
@@ -41,7 +41,9 @@ std::coroutine_handle<> counting_semaphore::try_release() noexcept {
     acquire_awaiter *resume_head = to_resume;
     if (resume_head == nullptr) {
         auto *node = awaiting.exchange(nullptr, std::memory_order_acquire);
-        if (node == nullptr) return nullptr; // no awaiting
+        if (node == nullptr) {
+            return nullptr; // no awaiting
+        }
 
         do {
             acquire_awaiter *tmp = node->next;

--- a/lib/co_context/io_context.cpp
+++ b/lib/co_context/io_context.cpp
@@ -2,10 +2,10 @@
 #include <mimalloc-new-delete.h>
 #endif
 #include "co_context/io_context.hpp"
-#include "co_context/utility/set_cpu_affinity.hpp"
-#include "co_context/co/semaphore.hpp"
 #include "co_context/co/condition_variable.hpp"
+#include "co_context/co/semaphore.hpp"
 #include "co_context/detail/eager_io_state.hpp"
+#include "co_context/utility/set_cpu_affinity.hpp"
 #include <atomic>
 
 // fold level = 3 (ctrl+a, ctrl+k, ctrl+3 in vscode)

--- a/lib/co_context/io_context.cpp
+++ b/lib/co_context/io_context.cpp
@@ -667,7 +667,7 @@ void io_context::run() {
         worker[0].init(0, this);
     }
 
-    if constexpr (config::use_standalone_completion_poller) {
+    if constexpr (config::is_using_standalone_completion_poller) {
         std::thread{[this] {
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
             log::i("ctx completion_poller runs on %d\n", gettid());
@@ -703,14 +703,14 @@ void io_context::run() {
         }
         // }
 
-        if constexpr (!config::use_standalone_completion_poller) {
+        if constexpr (!config::is_using_standalone_completion_poller) {
             // TODO judge the memory order (relaxed may cause bugs)
             // TODO consider reap_poll_rounds and reap_overflow_buf
             if (requests_to_reap > 0) [[likely]] {
                 auto num = ring.cq_ready_relaxed();
 
                 // io_context can block itself in the following situation
-                if constexpr (config::worker_threads_number == 0 && config::use_wait_and_notify) {
+                if constexpr (config::worker_threads_number == 0 && config::is_using_wait_and_notify) {
                     if (num == 0 && !has_task_ready) [[unlikely]] {
                         const liburingcxx::cq_entry *_;
                         ring.wait_cq_entry(_);

--- a/lib/co_context/net/inet_address.cpp
+++ b/lib/co_context/net/inet_address.cpp
@@ -36,18 +36,20 @@ inet_address::inet_address(uint16_t port, bool isIpv6) noexcept {
     if (isIpv6) {
         std::memset(&addr6, 0, sizeof(addr6));
         addr6.sin6_family = AF_INET6;
-        if constexpr (config::loopback_only)
+        if constexpr (config::loopback_only) {
             addr6.sin6_addr = in6addr_loopback;
-        else
+        } else {
             addr6.sin6_addr = in6addr_any;
+        }
         addr6.sin6_port = htons(port);
     } else {
         std::memset(&addr, 0, sizeof(addr));
         addr.sin_family = AF_INET;
-        if constexpr (config::loopback_only)
+        if constexpr (config::loopback_only) {
             addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-        else
+        } else {
             addr.sin_addr.s_addr = htonl(INADDR_ANY);
+        }
         addr.sin_port = htons(port);
     }
 }
@@ -82,14 +84,17 @@ std::string inet_address::to_ip_port() const {
     char buf[32];
     snprintf(buf, sizeof buf, ":%u", port());
 
-    if (family() == AF_INET6)
+    if (family() == AF_INET6) {
         return "[" + to_ip() + "]" + buf;
-    else
+    } else {
         return to_ip() + buf;
+    }
 }
 
 bool inet_address::operator==(const inet_address &rhs) const noexcept {
-    if (family() != rhs.family()) return false;
+    if (family() != rhs.family()) {
+        return false;
+    }
     if (family() == AF_INET) {
         return addr.sin_port == rhs.addr.sin_port
                && addr.sin_addr.s_addr == rhs.addr.sin_addr.s_addr;
@@ -114,7 +119,9 @@ bool inet_address::resolve(
         log::v("ip port: %s\n", addr.to_ip_port().data());
     }
 
-    if (addrs.empty()) return false;
+    if (addrs.empty()) {
+        return false;
+    }
     out = addrs.back(); // for ipv4 precedence
     return true;
 }
@@ -126,10 +133,11 @@ std::vector<inet_address> inet_address::resolve_all(
     struct addrinfo *result = nullptr;
     int err = getaddrinfo(hostname.data(), nullptr, hints, &result);
     if (err != 0) {
-        if (err == EAI_SYSTEM)
+        if (err == EAI_SYSTEM) {
             perror("inet_address::resolve");
-        else
+        } else {
             fprintf(stderr, "inet_address::resolve: %s\n", gai_strerror(err));
+        }
         return ret;
     }
 

--- a/lib/co_context/net/inet_address.cpp
+++ b/lib/co_context/net/inet_address.cpp
@@ -36,7 +36,7 @@ inet_address::inet_address(uint16_t port, bool is_ipv6) noexcept {
     if (is_ipv6) {
         std::memset(&addr6, 0, sizeof(addr6));
         addr6.sin6_family = AF_INET6;
-        if constexpr (config::loopback_only) {
+        if constexpr (config::is_loopback_only) {
             addr6.sin6_addr = in6addr_loopback;
         } else {
             addr6.sin6_addr = in6addr_any;
@@ -45,7 +45,7 @@ inet_address::inet_address(uint16_t port, bool is_ipv6) noexcept {
     } else {
         std::memset(&addr, 0, sizeof(addr));
         addr.sin_family = AF_INET;
-        if constexpr (config::loopback_only) {
+        if constexpr (config::is_loopback_only) {
             addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
         } else {
             addr.sin_addr.s_addr = htonl(INADDR_ANY);

--- a/lib/co_context/net/socket.cpp
+++ b/lib/co_context/net/socket.cpp
@@ -5,7 +5,7 @@ namespace co_context {
 class inet_address;
 
 socket &socket::bind(const inet_address &addr) {
-    int res = ::bind(sockfd, addr.get_sockaddr(), addr.length());
+    const int res = ::bind(sockfd, addr.get_sockaddr(), addr.length());
     if (res != 0) {
         perror("socket::bind");
         abort();
@@ -15,7 +15,7 @@ socket &socket::bind(const inet_address &addr) {
 }
 
 socket &socket::listen() {
-    int res = ::listen(sockfd, SOMAXCONN);
+    const int res = ::listen(sockfd, SOMAXCONN);
     if (res != 0) {
         perror("socket::listen");
         abort();
@@ -25,7 +25,7 @@ socket &socket::listen() {
 }
 
 socket &socket::set_reuse_addr(bool on) {
-    int optval = on;
+    int optval = static_cast<int>(on);
     if (::setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof optval)
         < 0) {
         perror("socket::set_reuse_addr");
@@ -48,7 +48,7 @@ socket &socket::set_tcp_no_delay(bool on) {
 inet_address socket::get_local_addr() const {
     struct sockaddr_storage localaddr;
     socklen_t addrlen = sizeof localaddr;
-    struct sockaddr *addr = reinterpret_cast<struct sockaddr *>(&localaddr);
+    auto *addr = reinterpret_cast<struct sockaddr *>(&localaddr);
     if (::getsockname(sockfd, addr, &addrlen) < 0) {
         perror("socket::get_local_addr");
     }
@@ -58,7 +58,7 @@ inet_address socket::get_local_addr() const {
 inet_address socket::get_peer_addr() const {
     struct sockaddr_storage peeraddr;
     socklen_t addrlen = sizeof peeraddr;
-    struct sockaddr *addr = reinterpret_cast<struct sockaddr *>(&peeraddr);
+    auto *addr = reinterpret_cast<struct sockaddr *>(&peeraddr);
     if (::getpeername(sockfd, addr, &addrlen) < 0) {
         perror("socket::get_peer_addr");
     }

--- a/test/cat.cpp
+++ b/test/cat.cpp
@@ -35,8 +35,9 @@ constexpr int count_blocks(size_t size, unsigned block_sz) noexcept {
 }
 
 void output(std::string_view s) noexcept {
-    for (char c : s)
+    for (char c : s) {
         putchar(c);
+    }
 }
 
 using uring = liburingcxx::uring<0>;

--- a/test/cat.cpp
+++ b/test/cat.cpp
@@ -17,11 +17,10 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <fcntl.h>
-// #include <sys/stat.h>
-#include <iostream>
-#include <filesystem>
 #include "uring/uring.hpp"
+#include <fcntl.h>
+#include <filesystem>
+#include <iostream>
 
 constexpr unsigned BLOCK_SZ = 1024;
 

--- a/test/ctx_swtch.cpp
+++ b/test/ctx_swtch.cpp
@@ -1,6 +1,6 @@
 #include "co_context/io_context.hpp"
-#include "co_context/utility/timing.hpp"
 #include "co_context/lazy_io.hpp"
+#include "co_context/utility/timing.hpp"
 
 using namespace co_context;
 
@@ -10,8 +10,9 @@ uint32_t count = 0;
 task<> run() {
     auto start = std::chrono::steady_clock::now();
 
-    while (++count < total_switch)
-        [[likely]] co_await lazy::yield();
+    while (++count < total_switch) {
+        co_await lazy::yield();
+    }
 
     if (count == total_switch) [[unlikely]] {
         auto end = std::chrono::steady_clock::now();
@@ -28,8 +29,9 @@ task<> run() {
 int main() {
     io_context ctx;
 
-    for (int i = 0; i < config::swap_capacity / 2; ++i)
+    for (int i = 0; i < config::swap_capacity / 2; ++i) {
         ctx.co_spawn(run());
+    }
 
     ctx.run();
 

--- a/test/fingerprint.cpp
+++ b/test/fingerprint.cpp
@@ -36,8 +36,9 @@ task<> run(co_context::socket sock) {
         offset &= ~(BLOCK_LEN - 1);
         co_await lazy::read(file_fd, as_buf(as_uint), offset);
         uint32_t hashcode = as_uint[0];
-        for (size_t i = 1; i < BLOCK_LEN / 4; ++i)
+        for (size_t i = 1; i < BLOCK_LEN / 4; ++i) {
             hashcode ^= as_uint[i];
+        }
         log("send hash", hashcode);
         co_await sock.send(as_buf(&hashcode), 0);
         // t_send = std::chrono::steady_clock::now();

--- a/test/fingerprint.cpp
+++ b/test/fingerprint.cpp
@@ -1,6 +1,6 @@
 #include "co_context/all.hpp"
-#include <filesystem>
 #include <fcntl.h>
+#include <filesystem>
 
 using namespace co_context;
 

--- a/test/fingerprint_blocking.cpp
+++ b/test/fingerprint_blocking.cpp
@@ -1,6 +1,6 @@
 #include "co_context/all.hpp"
-#include <filesystem>
 #include <fcntl.h>
+#include <filesystem>
 
 using namespace co_context;
 

--- a/test/fingerprint_client.cpp
+++ b/test/fingerprint_client.cpp
@@ -1,10 +1,10 @@
 #include "co_context/all.hpp"
-#include <string_view>
-#include <filesystem>
-#include <fcntl.h>
-#include <random>
 #include <atomic>
 #include <chrono>
+#include <fcntl.h>
+#include <filesystem>
+#include <random>
+#include <string_view>
 
 using namespace co_context;
 

--- a/test/generator_test.cpp
+++ b/test/generator_test.cpp
@@ -194,8 +194,9 @@ zip(Rs &&...rs) {
 
 void value_type_example() {
     std::vector<std::string_view> s1 = to_vector(string_views());
-    for (auto &s : s1)
+    for (auto &s : s1) {
         std::printf("\"%*s\"\n", (int)s.size(), s.data());
+    }
 
     std::printf("\n");
 

--- a/test/httpd.cpp
+++ b/test/httpd.cpp
@@ -121,8 +121,9 @@ void check_for_index_file() {
  * */
 
 void strtolower(char *str) {
-    for (; *str; ++str)
+    for (; *str; ++str) {
         *str = (char)tolower(*str);
+    }
 }
 
 /*
@@ -148,11 +149,14 @@ int setup_listening_socket(int port) {
     struct sockaddr_in srv_addr;
 
     sock = socket(PF_INET, SOCK_STREAM, 0);
-    if (sock == -1) fatal_error("socket()");
+    if (sock == -1) {
+        fatal_error("socket()");
+    }
 
     int enable = 1;
-    if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0)
+    if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int)) < 0) {
         fatal_error("setsockopt(SO_REUSEADDR)");
+    }
 
     std::memset(&srv_addr, 0, sizeof(srv_addr));
     srv_addr.sin_family = AF_INET;
@@ -162,10 +166,13 @@ int setup_listening_socket(int port) {
     /* We bind to a port and turn this socket into a listening
      * socket.
      * */
-    if (bind(sock, (const struct sockaddr *)&srv_addr, sizeof(srv_addr)) < 0)
+    if (bind(sock, (const struct sockaddr *)&srv_addr, sizeof(srv_addr)) < 0) {
         fatal_error("bind()");
+    }
 
-    if (listen(sock, 10) < 0) fatal_error("listen()");
+    if (listen(sock, 10) < 0) {
+        fatal_error("listen()");
+    }
 
     return (sock);
 }
@@ -259,7 +266,9 @@ void copy_file_contents(char *file_path, off_t file_size, struct iovec *iov) {
 
     char *buf = reinterpret_cast<char *>(zh_malloc(file_size));
     fd = open(file_path, O_RDONLY);
-    if (fd < 0) fatal_error("read");
+    if (fd < 0) {
+        fatal_error("read");
+    }
 
     /* We should really check for short reads here */
     int ret = read(fd, buf, file_size);
@@ -279,7 +288,9 @@ void copy_file_contents(char *file_path, off_t file_size, struct iovec *iov) {
 
 const char *get_filename_ext(const char *filename) {
     const char *dot = strrchr(filename, '.');
-    if (!dot || dot == filename) return "";
+    if (!dot || dot == filename) {
+        return "";
+    }
     return dot + 1;
 }
 
@@ -314,24 +325,33 @@ void send_headers(const char *path, off_t len, struct iovec *iov) {
      * we turn the extension into lower case before checking.
      * */
     const char *file_ext = get_filename_ext(small_case_path);
-    if (strcmp("jpg", file_ext) == 0)
+    if (strcmp("jpg", file_ext) == 0) {
         strcpy(send_buffer, "Content-Type: image/jpeg\r\n");
-    if (strcmp("jpeg", file_ext) == 0)
+    }
+    if (strcmp("jpeg", file_ext) == 0) {
         strcpy(send_buffer, "Content-Type: image/jpeg\r\n");
-    if (strcmp("png", file_ext) == 0)
+    }
+    if (strcmp("png", file_ext) == 0) {
         strcpy(send_buffer, "Content-Type: image/png\r\n");
-    if (strcmp("gif", file_ext) == 0)
+    }
+    if (strcmp("gif", file_ext) == 0) {
         strcpy(send_buffer, "Content-Type: image/gif\r\n");
-    if (strcmp("htm", file_ext) == 0)
+    }
+    if (strcmp("htm", file_ext) == 0) {
         strcpy(send_buffer, "Content-Type: text/html\r\n");
-    if (strcmp("html", file_ext) == 0)
+    }
+    if (strcmp("html", file_ext) == 0) {
         strcpy(send_buffer, "Content-Type: text/html\r\n");
-    if (strcmp("js", file_ext) == 0)
+    }
+    if (strcmp("js", file_ext) == 0) {
         strcpy(send_buffer, "Content-Type: application/javascript\r\n");
-    if (strcmp("css", file_ext) == 0)
+    }
+    if (strcmp("css", file_ext) == 0) {
         strcpy(send_buffer, "Content-Type: text/css\r\n");
-    if (strcmp("txt", file_ext) == 0)
+    }
+    if (strcmp("txt", file_ext) == 0) {
         strcpy(send_buffer, "Content-Type: text/plain\r\n");
+    }
     slen = strlen(send_buffer);
     iov[2].iov_base = zh_malloc(slen);
     iov[2].iov_len = slen;

--- a/test/httpd.cpp
+++ b/test/httpd.cpp
@@ -1,15 +1,14 @@
-#include <stdio.h>
-#include <netinet/in.h>
-#include <string.h>
-#include <ctype.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <signal.h>
-// #include <liburing.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <sys/utsname.h>
 #include "uring/uring.hpp"
+#include <cctype>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/stat.h>
+#include <sys/utsname.h>
+#include <unistd.h>
 
 #define SERVER_STRING       "Server: zerohttpd/0.1\r\n"
 #define DEFAULT_SERVER_PORT 8000

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,9 +1,9 @@
 #include "co_context/io_context.hpp"
 #include "co_context/lazy_io.hpp"
-#include "co_context/net/socket.hpp"
 #include "co_context/net/acceptor.hpp"
-#include <filesystem>
+#include "co_context/net/socket.hpp"
 #include <fcntl.h>
+#include <filesystem>
 #include <iostream>
 
 int main(int argc, char *argv[]) {

--- a/test/nop.cpp
+++ b/test/nop.cpp
@@ -1,12 +1,12 @@
 #include "co_context/io_context.hpp"
+#include "co_context/eager_io.hpp"
 #include "co_context/net/acceptor.hpp"
 #include "co_context/utility/buffer.hpp"
-#include "co_context/eager_io.hpp"
-#include <filesystem>
-#include <random>
-#include <fcntl.h>
 #include <atomic>
 #include <chrono>
+#include <fcntl.h>
+#include <filesystem>
+#include <random>
 
 using namespace co_context;
 

--- a/test/nop.cpp
+++ b/test/nop.cpp
@@ -45,8 +45,9 @@ int main(int argc, char *argv[]) {
 
     io_context context;
 
-    for (int i = 0; i < concur; ++i)
+    for (int i = 0; i < concur; ++i) {
         context.co_spawn(gen_task());
+    }
 
     context.run();
 

--- a/test/nop_thread.cpp
+++ b/test/nop_thread.cpp
@@ -1,5 +1,5 @@
-#include <iostream>
 #include <atomic>
+#include <iostream>
 #include <thread>
 #include <vector>
 

--- a/test/photon_pingpong_client.cpp
+++ b/test/photon_pingpong_client.cpp
@@ -13,10 +13,14 @@ task<> session(Socket sock) {
 
     while (true) {
         int nw = co_await sock.send(buf);
-        if (nw <= 0) break;
+        if (nw <= 0) {
+            break;
+        }
 
         int nr = co_await sock.recv(buf);
-        if (nr <= 0) break;
+        if (nr <= 0) {
+            break;
+        }
     }
 }
 

--- a/test/photon_streaming_client.cpp
+++ b/test/photon_streaming_client.cpp
@@ -12,7 +12,9 @@ task<> recv_session(Socket sock) {
 
     while (true) {
         int nr = co_await sock.recv(buf);
-        if (nr <= 0) break;
+        if (nr <= 0) {
+            break;
+        }
     }
 }
 
@@ -21,7 +23,9 @@ task<> send_session(Socket sock) {
 
     while (true) {
         int nw = co_await sock.send(buf);
-        if (nw <= 0) break;
+        if (nw <= 0) {
+            break;
+        }
     }
 }
 

--- a/test/rand4kr.cpp
+++ b/test/rand4kr.cpp
@@ -1,13 +1,13 @@
 #include "co_context/io_context.hpp"
+#include "co_context/eager_io.hpp"
+#include "co_context/lazy_io.hpp"
 #include "co_context/net/acceptor.hpp"
 #include "co_context/utility/buffer.hpp"
-#include "co_context/lazy_io.hpp"
-#include "co_context/eager_io.hpp"
-#include <filesystem>
-#include <random>
-#include <fcntl.h>
 #include <atomic>
 #include <chrono>
+#include <fcntl.h>
+#include <filesystem>
+#include <random>
 #include <semaphore>
 
 using namespace co_context;

--- a/test/rand4kr_blocking.cpp
+++ b/test/rand4kr_blocking.cpp
@@ -1,13 +1,13 @@
 #include "co_context/io_context.hpp"
+#include "co_context/eager_io.hpp"
+#include "co_context/lazy_io.hpp"
 #include "co_context/net/acceptor.hpp"
 #include "co_context/utility/buffer.hpp"
-#include "co_context/lazy_io.hpp"
-#include "co_context/eager_io.hpp"
-#include <filesystem>
-#include <random>
-#include <fcntl.h>
 #include <atomic>
 #include <chrono>
+#include <fcntl.h>
+#include <filesystem>
+#include <random>
 
 using namespace co_context;
 

--- a/test/rand4kr_callback.cpp
+++ b/test/rand4kr_callback.cpp
@@ -1,13 +1,12 @@
 #include "co_context/io_context.hpp"
+#include "co_context/lazy_io.hpp"
 #include "co_context/net/acceptor.hpp"
 #include "co_context/utility/buffer.hpp"
-#include "co_context/lazy_io.hpp"
-
-#include <filesystem>
-#include <random>
-#include <fcntl.h>
 #include <atomic>
 #include <chrono>
+#include <fcntl.h>
+#include <filesystem>
+#include <random>
 
 using namespace co_context;
 

--- a/test/rand4kr_callback.cpp
+++ b/test/rand4kr_callback.cpp
@@ -75,8 +75,9 @@ int main(int argc, char *argv[]) {
 
     int concur = std::min(MAX_ON_FLY, times);
     remain.store(times - concur);
-    for (int i = 0; i < concur; ++i)
+    for (int i = 0; i < concur; ++i) {
         context.co_spawn(run());
+    }
 
     context.run();
 

--- a/test/rand4kr_forloop.cpp
+++ b/test/rand4kr_forloop.cpp
@@ -1,11 +1,11 @@
 #include "co_context/io_context.hpp"
 #include "co_context/lazy_io.hpp"
-#include <filesystem>
-#include <random>
-#include <fcntl.h>
 #include <atomic>
 #include <chrono>
 #include <ctime>
+#include <fcntl.h>
+#include <filesystem>
+#include <random>
 
 using namespace co_context;
 

--- a/test/rand4kr_multithread_blocking.cpp
+++ b/test/rand4kr_multithread_blocking.cpp
@@ -1,12 +1,12 @@
 #include "co_context/io_context.hpp"
-#include <filesystem>
-#include <random>
-#include <fcntl.h>
 #include <atomic>
 #include <chrono>
+#include <ctime>
+#include <fcntl.h>
+#include <filesystem>
+#include <random>
 #include <thread>
 #include <vector>
-#include <ctime>
 
 int file_fd;
 size_t file_size;

--- a/test/rand4kw_callback.cpp
+++ b/test/rand4kw_callback.cpp
@@ -84,8 +84,9 @@ int main(int argc, char *argv[]) {
 
     io_context context;
 
-    for (unsigned i = 0; i < std::min(MAX_ON_FLY, times); ++i)
+    for (unsigned i = 0; i < std::min(MAX_ON_FLY, times); ++i) {
         context.co_spawn(run());
+    }
 
     context.run();
 

--- a/test/rand4kw_callback.cpp
+++ b/test/rand4kw_callback.cpp
@@ -1,12 +1,12 @@
 #include "co_context/io_context.hpp"
+#include "co_context/lazy_io.hpp"
 #include "co_context/net/acceptor.hpp"
 #include "co_context/utility/buffer.hpp"
-#include "co_context/lazy_io.hpp"
-#include <filesystem>
-#include <random>
-#include <fcntl.h>
 #include <atomic>
 #include <chrono>
+#include <fcntl.h>
+#include <filesystem>
+#include <random>
 
 using namespace co_context;
 

--- a/test/swtch.cpp
+++ b/test/swtch.cpp
@@ -21,8 +21,9 @@ constexpr uint32_t total_switch = 2e9;
 uint32_t count = 0;
 
 task<> f(const swtch &to) {
-    while (count++ < total_switch)
-        [[likely]] co_await to;
+    while (count++ < total_switch) {
+        co_await to;
+    }
 }
 
 bool g() {


### PR DESCRIPTION
- We fix a bug that caused the `exception_ptr` can not be destruct in a detached task (A detached task is a co_spawned task).
- Introduce clangd and clang-tidy to my personal develop environment. So lots of code has been tidied up