### PR TITLE
build(cmake): lower CMAKE_C_STANDARD to 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20.0)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_STANDARD 11)
 option(FORCE_TO_USE_MIMALLOC "Force the use of mimalloc version 2.0 or above" OFF)
 
 if (NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
per
https://cmake.org/cmake/help/latest/prop_gbl/CMAKE_C_KNOWN_FEATURES.html, c_std_17 was introduced in CMake 3.21, while the required CMake version is 3.20. which is packaged by RHEL/RockyLinux 9, so it would be nice if we could build with co_context on these distro releases using the shipped CMake.

so, in this change, CMAKE_C_STANDARD is changed from 17 to 11. this change should have minimum impact, as co_context is a C++20 project which does not contain C source code.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>