### PR TITLE
Update liburingcxx to catch up with liburing.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,6 +5,7 @@ TabWidth: 4
 Language: Cpp
 # AlignAfterOpenBracket: AlwaysBreak # BlockIndent
 AlignAfterOpenBracket: BlockIndent # BlockIndent
+AlignArrayOfStructures: Right
 AlignConsecutiveBitFields: true
 AlignConsecutiveMacros: true
 AlignEscapedNewlines: Left
@@ -40,20 +41,21 @@ Cpp11BracedListStyle: true
 EmptyLineBeforeAccessModifier: Always
 FixNamespaceComments: true
 IndentCaseLabels: true
-InsertBraces: true
 IndentExternBlock: Indent
 IndentGotoLabels: true
 IndentPPDirectives: None
-# IndentPragmas: false
-IndentRequires: true # llvm 14
+IndentRequires: true # clang-format 14
 IndentWrappedFunctionNames: false
+InsertBraces: true # clang-format 15
+LambdaBodyIndentation: Signature
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: Inner
+PackConstructorInitializers: CurrentLine # clang-format 14
 PointerAlignment: Right
 QualifierAlignment: Left
 ReflowComments: true
-# RequiresClausePosition: OwnLine # llvm 15
+RequiresClausePosition: OwnLine # clang-format 15
 SeparateDefinitionBlocks: Always
 ShortNamespaceLines: 5
 SortIncludes:    false

--- a/README.md
+++ b/README.md
@@ -11,13 +11,20 @@ co_context 基于 Linux io_uring，其性能通常优于 epoll。
 2. 并发支持: `mutex`, `semaphore`, `condition_variable`, `channel`。
 3. 调度提示: `yield`
 
-## 编译和运行环境
+## 编译和运行
+
+### 依赖
 
 1. [Optional] [mimalloc](https://github.com/microsoft/mimalloc)  从包管理器或源代码安装。
 2. Linux 内核版本 >= 5.6，建议 >= 5.11，越新越好。
     - 运行 `uname -r` 即可查看你的内核版本。
     - 由于开发环境是 Linux 5.19，在其他版本下可能出现兼容性错误。如遇问题，请将报错发到[issue](https://github.com/Codesire-Deng/co_context/issues)或B站私信[@等疾风](https://space.bilibili.com/35186937)，非常感谢！
     - **docker 将继承宿主机的 Linux 内核版本**。 因此，docker 无法解决 Linux 内核版本过低的问题。
+
+### 编译命令
+
+1. 根目录下执行：`cmake -B build && cmake --build build -j`
+2. 运行代码示例：`build/example/timer`
 
 ## 代码示例
 

--- a/doc/README_en.md
+++ b/doc/README_en.md
@@ -12,13 +12,22 @@ A C++20 **coroutine** framework offering highly-concurrent I/O with a reasonable
 2. Concurrency support: `mutex`, `semaphore`, `condition_variable`, `channel`. Provides thread-safty between coroutines. 
 3. Dispatch hint: `yield`
 
-## Requirement
+## Build
+
+### Requirement
 
 1. [Optional] [mimalloc](https://github.com/microsoft/mimalloc). You may install it by package manager or from source.
 2. **Linux kernel** >= 5.6. The newer the better.
     - Run `uname -r` to see your kernel version.
     - Since we are developing under Linux 6.0, if you have met some thing wrong, please open an [issue](https://github.com/Codesire-Deng/co_context/issues) and I would appreciate it very much.
     - **docker will inherit the Linux kernel of the host**. Therefore, docker does no help to kernel version problems.
+
+### Build from source
+
+```bash
+cmake -B build && cmake --build build -j
+build/example/timer # Run an example
+```
 
 ## Example
 

--- a/include/co_context/co/condition_variable.hpp
+++ b/include/co_context/co/condition_variable.hpp
@@ -18,7 +18,8 @@ namespace detail {
         using mutex = co_context::mutex;
 
         explicit cv_wait_awaiter(condition_variable & cv, mutex & mtx) noexcept
-            : lock_awaken_handle(mtx.lock()), cv(cv) {
+            : lock_awaken_handle(mtx.lock())
+            , cv(cv) {
         }
 
         static constexpr bool await_ready() noexcept {

--- a/include/co_context/detail/reap_info.hpp
+++ b/include/co_context/detail/reap_info.hpp
@@ -30,10 +30,13 @@ namespace detail {
         reap_info() noexcept : io_info(nullptr), result(0), flags(0) {}
 
         reap_info(task_info *io_info, int32_t result, uint32_t flags) noexcept
-            : io_info(io_info), result(result), flags(flags) {}
+            : io_info(io_info)
+            , result(result)
+            , flags(flags) {}
 
         explicit reap_info(std::coroutine_handle<> handle) noexcept
-            : handle(handle), flags(co_spawn_flag) {}
+            : handle(handle)
+            , flags(co_spawn_flag) {}
 
         bool is_co_spawn() const noexcept { return flags == co_spawn_flag; }
     };

--- a/include/co_context/io_context.hpp
+++ b/include/co_context/io_context.hpp
@@ -233,7 +233,8 @@ class [[nodiscard]] io_context final {
     }
 
     io_context(unsigned io_uring_entries = config::default_io_uring_entries)
-        : ring(io_uring_entries), sqring_entries(io_uring_entries) {
+        : ring(io_uring_entries)
+        , sqring_entries(io_uring_entries) {
         init();
     }
 

--- a/include/uring/arch/syscall-defs.h
+++ b/include/uring/arch/syscall-defs.h
@@ -11,9 +11,9 @@ static inline int __sys_open(const char *pathname, int flags, mode_t mode) {
      * Some architectures don't have __NR_open, but __NR_openat.
      */
 #ifdef __NR_open
-    return __do_syscall3(__NR_open, pathname, flags, mode);
+    return (int)__do_syscall3(__NR_open, pathname, flags, mode);
 #else
-    return __do_syscall4(__NR_openat, AT_FDCWD, pathname, flags, mode);
+    return (int)__do_syscall4(__NR_openat, AT_FDCWD, pathname, flags, mode);
 #endif
 }
 

--- a/include/uring/detail/cq.hpp
+++ b/include/uring/detail/cq.hpp
@@ -52,7 +52,7 @@ namespace detail {
     struct cq_entry_getter {
         unsigned submit;
         unsigned wait_num;
-        unsigned getFlags;
+        unsigned get_flags;
         int size;
         void *arg;
     };

--- a/include/uring/io_uring.h
+++ b/include/uring/io_uring.h
@@ -56,6 +56,7 @@ struct io_uring_sqe {
 		__u32		hardlink_flags;
 		__u32		xattr_flags;
 		__u32		msg_ring_flags;
+		__u32		uring_cmd_flags;
 	};
 	__u64	user_data;	/* data to be passed back at completion time */
 	/* pack this to avoid bogus arm OABI complaints */
@@ -218,6 +219,14 @@ enum io_uring_op {
 	/* this goes last, obviously */
 	IORING_OP_LAST,
 };
+
+/*
+ * sqe->uring_cmd_flags
+ * IORING_URING_CMD_FIXED	use registered buffer; pass thig flag
+ *				along with setting sqe->buf_index.
+ */
+#define IORING_URING_CMD_FIXED	(1U << 0)
+
 
 /*
  * sqe->fsync_flags

--- a/include/uring/syscall.hpp
+++ b/include/uring/syscall.hpp
@@ -20,8 +20,8 @@ static inline void *ERR_PTR(intptr_t n) {
     return (void *)n;
 }
 
-static inline intptr_t PTR_ERR(const void *ptr) {
-    return (intptr_t)ptr;
+static inline int PTR_ERR(const void *ptr) {
+    return (int)(intptr_t)ptr;
 }
 
 static inline bool IS_ERR(const void *ptr) {


### PR DESCRIPTION
Update liburingcxx to catch up with liburing as of 2022/10/25.

- Catch up with fix of liburing from 2022/10/20 to 2022/10/25.
- Enhance performance for `_get_cq_entry()` with templated `has_ts` flag.
- Update clang-format to 15 and add some format styles.
- Add example for compilation.