### PR TITLE
build(github): add a lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  lint-cxx:
+    name: C++ Source Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check on C/C++ sources
+      uses: jidicula/clang-format-action@v4.9.0
+      with:
+        clang-format-version: '15'
+        exclude-regex: 'include/uring'


### PR DESCRIPTION
for checking the clang-format compliance.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>