### PR TITLE
fix a move constructor of `task`

### DIFF
--- a/include/co_context/task.hpp
+++ b/include/co_context/task.hpp
@@ -260,7 +260,7 @@ class [[nodiscard("Did you forget to co_await?")]] task {
         : handle(current) {
     }
 
-    task(task && other) noexcept : handle(other) {
+    task(task && other) noexcept : handle(other.handle) {
         other.handle = nullptr;
     }
 

--- a/test/coro_lifetime.cpp
+++ b/test/coro_lifetime.cpp
@@ -17,15 +17,15 @@ task<S> coro_copy(S x) {
     co_return x;
 }
 
+/* Error
 task<S &> coro_ref(S x) {
-    co_return x;
+    co_return x; // Dangling reference!
 }
+*/
 
 task<> coro(S s) {
     printf("coro_copy:\n");
     S res0 = co_await coro_copy(s);
-    printf("coro_ref:\n");
-    S res1 = co_await coro_ref(s);
     printf("coro finished\n");
     co_return;
 }


### PR DESCRIPTION
- The move ctor of `task` had set a coroutine handle to another `task` by mistake. Now it is corrected.
- Drop an test case for coroutine lifetime. It had caused compilation failures.