### PR TITLE
Lint & build: code quality improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ add_compile_definitions(LIBURINGCXX_KERNEL_VERSION_MAJOR=${kernel_version_major}
 add_compile_definitions(LIBURINGCXX_KERNEL_VERSION_PATCHLEVEL=${kernel_version_patchlevel})
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.3.0")
+        message(FATAL_ERROR "Insufficient gcc version, requires gcc 11.3 or above")
+    endif()
+
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
     if (${CMAKE_BUILD_TYPE} MATCHES Debug)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 
     message("CMAKE_CXX_FLAGS = ${CMAKE_CXX_FLAGS}")
 else()
-    message(WARNING "Not using GNU g++ for CXX, the compiler id is ${CMAKE_CXX_COMPILER_ID}.")
+    message(FATAL_ERROR "GNU g++ is required, but the compiler id is ${CMAKE_CXX_COMPILER_ID}.\nPS: Neither Clang nor MSVC are supported yet.")
 endif()
 
 if (FORCE_TO_USE_MIMALLOC)

--- a/example/echo_server_asio.cppx
+++ b/example/echo_server_asio.cppx
@@ -1,4 +1,5 @@
 #include <boost/asio.hpp>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
@@ -8,7 +9,7 @@ using boost::asio::ip::tcp;
 
 class session : public std::enable_shared_from_this<session> {
   public:
-    session(tcp::socket socket) : socket_(std::move(socket)) {}
+    explicit session(tcp::socket socket) : socket_(std::move(socket)) {}
 
     void start() { do_read(); }
 
@@ -46,7 +47,7 @@ class session : public std::enable_shared_from_this<session> {
 
 class server {
   public:
-    server(boost::asio::io_context &io_context, short port)
+    server(boost::asio::io_context &io_context, uint16_t port)
         : acceptor_(io_context, tcp::endpoint(tcp::v4(), port)) {
         do_accept();
     }

--- a/example/sem.cpp
+++ b/example/sem.cpp
@@ -37,7 +37,7 @@ class alignas(128 /*std::hardware_destructive_interference_size*/) Guide {
         started_at = std::chrono::high_resolution_clock::now();
     }
 
-    task<void> initial_delay() { co_await timeout(delay * time_tick); }
+    task<void> initial_delay() const { co_await timeout(delay * time_tick); }
 
     task<void> occupy_sema() {
         wait_on_sema = static_cast<unsigned>(

--- a/include/co_context/co/condition_variable.hpp
+++ b/include/co_context/co/condition_variable.hpp
@@ -53,7 +53,7 @@ class condition_variable final {
     using cv_wait_awaiter = detail::cv_wait_awaiter;
     using task_info = detail::task_info;
     using T = config::condition_variable_counting_t;
-    inline static constexpr T notify_all_flag = bit_top<T>();
+    inline static constexpr T notify_all_flag = bit_top<T>;
 
   public:
     condition_variable() noexcept

--- a/include/co_context/co/condition_variable.hpp
+++ b/include/co_context/co/condition_variable.hpp
@@ -11,42 +11,46 @@ namespace co_context {
 
 class condition_variable;
 
-namespace detail {
+} // namespace co_context
 
-    class [[nodiscard("Did you forget to co_await?")]] cv_wait_awaiter final {
-      public:
-        using mutex = co_context::mutex;
+namespace co_context::detail {
 
-        explicit cv_wait_awaiter(condition_variable & cv, mutex & mtx) noexcept
-            : lock_awaken_handle(mtx.lock())
-            , cv(cv) {
-        }
+class [[nodiscard("Did you forget to co_await?")]] cv_wait_awaiter final {
+  public:
+    using mutex = co_context::mutex;
 
-        static constexpr bool await_ready() noexcept {
-            return false;
-        }
+    explicit cv_wait_awaiter(condition_variable & cv, mutex & mtx) noexcept
+        : lock_awaken_handle(mtx.lock())
+        , cv(cv) {
+    }
 
-        void await_suspend(std::coroutine_handle<> current) noexcept;
+    static constexpr bool await_ready() noexcept {
+        return false;
+    }
 
-        /**
-         * @detail the lock must be held, when io_context resume me.
-         * @detail io_context will call mutex::lock_awaiter::register_awaiting
-         **/
-        constexpr void await_resume() const noexcept {
-        }
+    void await_suspend(std::coroutine_handle<> current) noexcept;
 
-      private:
-        mutex::lock_awaiter lock_awaken_handle;
-        condition_variable &cv;
-        // mutex &mtx;
-        // std::coroutine_handle<> handle;
+    /**
+     * @detail the lock must be held, when io_context resume me.
+     * @detail io_context will call mutex::lock_awaiter::register_awaiting
+     **/
+    constexpr void await_resume() const noexcept {
+    }
 
-        cv_wait_awaiter *next = nullptr;
-        friend class ::co_context::condition_variable;
-        friend class ::co_context::io_context;
-    };
+  private:
+    mutex::lock_awaiter lock_awaken_handle;
+    condition_variable &cv;
+    // mutex &mtx;
+    // std::coroutine_handle<> handle;
 
-} // namespace detail
+    cv_wait_awaiter *next = nullptr;
+    friend class ::co_context::condition_variable;
+    friend class ::co_context::io_context;
+};
+
+} // namespace co_context::detail
+
+namespace co_context {
 
 class condition_variable final {
   private:
@@ -101,7 +105,7 @@ class condition_variable final {
     void to_resume_fetch_all() noexcept;
 
   public:
-    static consteval auto __task_offset() noexcept {
+    static consteval auto __task_offset() /*NOLINT*/ noexcept {
         return offsetof(condition_variable, notify_task);
     }
 };

--- a/include/co_context/co/semaphore.hpp
+++ b/include/co_context/co/semaphore.hpp
@@ -70,7 +70,7 @@ class counting_semaphore final {
     task_info awaken_task;
 
   public:
-    static consteval auto __task_offset() noexcept {
+    static consteval auto __task_offset() /*NOLINT*/ noexcept {
         return offsetof(counting_semaphore, awaken_task);
     }
 };

--- a/include/co_context/config.hpp
+++ b/include/co_context/config.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "uring/io_uring.h"
+#include "uring/uring_define.hpp"
 #include <bit>
 #include <cstddef>
 #include <cstdint>
@@ -9,7 +10,7 @@ namespace co_context {
 
 namespace config {
 
-    // ======================== io_uring configuration ========================
+    // ================== io_uring/liburingcxx configuration ==================
     inline constexpr unsigned io_uring_setup_flags = 0;
     // inline constexpr unsigned io_uring_setup_flags = IORING_SETUP_SQPOLL;
 
@@ -23,6 +24,8 @@ namespace config {
         bool(io_uring_setup_flags & IORING_SETUP_SQPOLL)
             ? 0
             : (IORING_SETUP_COOP_TASKRUN | IORING_SETUP_TASKRUN_FLAG);
+
+    inline constexpr uint64_t uring_setup_flags = 0;
     // ========================================================================
 
     // ========================== CPU configuration ===========================

--- a/include/co_context/detail/cv_task_meta.hpp
+++ b/include/co_context/detail/cv_task_meta.hpp
@@ -3,20 +3,15 @@
 #include "co_context/co/condition_variable.hpp"
 #include "co_context/detail/task_info.hpp"
 
-namespace co_context {
+namespace co_context::detail {
 
-namespace detail {
+static_assert(std::is_standard_layout_v<condition_variable>);
 
-    static_assert(std::is_standard_layout_v<condition_variable>);
+inline condition_variable *as_condition_variable(task_info *task_ptr) noexcept {
+    using cv = condition_variable;
+    return reinterpret_cast<cv *> /*NOLINT*/ (
+        reinterpret_cast<uintptr_t>(task_ptr) - cv::__task_offset()
+    );
+}
 
-    inline condition_variable *as_condition_variable(task_info *task_ptr
-    ) noexcept {
-        using cv = condition_variable;
-        return reinterpret_cast<cv *>(
-            reinterpret_cast<uintptr_t>(task_ptr) - cv::__task_offset()
-        );
-    }
-
-} // namespace detail
-
-} // namespace co_context
+} // namespace co_context::detail

--- a/include/co_context/detail/eager_io_state.hpp
+++ b/include/co_context/detail/eager_io_state.hpp
@@ -2,15 +2,12 @@
 
 #include "co_context/config.hpp"
 
-namespace co_context {
+namespace co_context::eager {
 
-namespace eager {
-    using io_state_t = config::eager_io_state_t;
+using io_state_t = config::eager_io_state_t;
 
-    inline constexpr io_state_t io_ready = 1U;
-    inline constexpr io_state_t io_wait = 1U << 1;
-    inline constexpr io_state_t io_detached = 1U << 2;
+inline constexpr io_state_t io_ready = 1U;
+inline constexpr io_state_t io_wait = 1U << 1;
+inline constexpr io_state_t io_detached = 1U << 2;
 
-}
-
-} // namespace co_context
+} // namespace co_context::eager

--- a/include/co_context/detail/reap_info.hpp
+++ b/include/co_context/detail/reap_info.hpp
@@ -10,37 +10,33 @@ class sq_entry;
 
 } // namespace liburingcxx
 
-namespace co_context {
+namespace co_context::detail {
 
-namespace detail {
+struct task_info;
 
-    struct task_info;
-
-    struct reap_info {
-        union {
-            std::coroutine_handle<> handle;
-            task_info *io_info;
-        };
-
-        int32_t result;
-        uint32_t flags;
-
-        inline static constexpr uint32_t co_spawn_flag = bit_top<uint32_t>;
-
-        reap_info() noexcept : io_info(nullptr), result(0), flags(0) {}
-
-        reap_info(task_info *io_info, int32_t result, uint32_t flags) noexcept
-            : io_info(io_info)
-            , result(result)
-            , flags(flags) {}
-
-        explicit reap_info(std::coroutine_handle<> handle) noexcept
-            : handle(handle)
-            , flags(co_spawn_flag) {}
-
-        bool is_co_spawn() const noexcept { return flags == co_spawn_flag; }
+struct reap_info {
+    union {
+        std::coroutine_handle<> handle;
+        task_info *io_info;
     };
 
-} // namespace detail
+    int32_t result;
+    uint32_t flags;
 
-} // namespace co_context
+    inline static constexpr uint32_t co_spawn_flag = bit_top<uint32_t>;
+
+    reap_info() noexcept : io_info(nullptr), result(0), flags(0) {}
+
+    reap_info(task_info *io_info, int32_t result, uint32_t flags) noexcept
+        : io_info(io_info)
+        , result(result)
+        , flags(flags) {}
+
+    explicit reap_info(std::coroutine_handle<> handle) noexcept
+        : handle(handle)
+        , flags(co_spawn_flag) {}
+
+    [[nodiscard]] bool is_co_spawn() const noexcept { return flags == co_spawn_flag; }
+};
+
+} // namespace co_context::detail

--- a/include/co_context/detail/reap_info.hpp
+++ b/include/co_context/detail/reap_info.hpp
@@ -25,7 +25,7 @@ namespace detail {
         int32_t result;
         uint32_t flags;
 
-        inline static constexpr uint32_t co_spawn_flag = bit_top<uint32_t>();
+        inline static constexpr uint32_t co_spawn_flag = bit_top<uint32_t>;
 
         reap_info() noexcept : io_info(nullptr), result(0), flags(0) {}
 

--- a/include/co_context/detail/sem_task_meta.hpp
+++ b/include/co_context/detail/sem_task_meta.hpp
@@ -2,18 +2,13 @@
 
 #include "co_context/co/semaphore.hpp"
 
-namespace co_context {
+namespace co_context::detail {
 
-namespace detail {
+inline counting_semaphore *as_counting_semaphore(task_info *task_ptr) noexcept {
+    using sem = counting_semaphore;
+    return reinterpret_cast<sem *> /*NOLINT*/ (
+        reinterpret_cast<uintptr_t>(task_ptr) - sem::__task_offset()
+    );
+}
 
-    inline counting_semaphore *as_counting_semaphore(task_info *task_ptr
-    ) noexcept {
-        using sem = counting_semaphore;
-        return reinterpret_cast<sem *>(
-            reinterpret_cast<uintptr_t>(task_ptr) - sem::__task_offset()
-        );
-    }
-
-} // namespace detail
-
-} // namespace co_context
+} // namespace co_context::detail

--- a/include/co_context/detail/submit_info.hpp
+++ b/include/co_context/detail/submit_info.hpp
@@ -8,47 +8,43 @@ class sq_entry;
 
 } // namespace liburingcxx
 
-namespace co_context {
+namespace co_context::detail {
 
-namespace detail {
+struct task_info;
 
-    struct task_info;
-
-    struct submit_info {
-        union {
-            void *ptr;
-            uintptr_t address;
-            uintptr_t handle;
-            uintptr_t sem_rel_task;
-            uintptr_t cv_notify_task;
-        };
-
-        union {
-            liburingcxx::sq_entry *available_sqe;
-            liburingcxx::sq_entry *submit_sqe;
-        };
+struct submit_info {
+    union {
+        void *ptr;
+        uintptr_t address;
+        uintptr_t handle;
+        uintptr_t sem_rel_task;
+        uintptr_t cv_notify_task;
     };
 
-    enum submit_type : uint8_t { co_spawn, sem_rel, cv_notify };
+    union {
+        liburingcxx::sq_entry *available_sqe;
+        liburingcxx::sq_entry *submit_sqe;
+    };
+};
 
-    /*
-    - submit:
-      - eager_sqe:  0u64,       sqe
-      - lazy_sqe:   0u64,       sqe
-      - link_sqe:   0u64,       sqe
-      - detach_sqe: 0u64,       sqe
-      - co_spawn:   handle(0),  available_sqe
-      - sem_rel:    task(1),    available_sqe
-      - cv_noti:    task(2),    available_sqe
-    */
+enum submit_type : uint8_t { co_spawn, sem_rel, cv_notify };
 
-    /*
-    - available:
-      - x,  available_sqe
-      - x,  available_sqe
-      - x,  available_sqe
-    */
+/*
+- submit:
+  - eager_sqe:  0u64,       sqe
+  - lazy_sqe:   0u64,       sqe
+  - link_sqe:   0u64,       sqe
+  - detach_sqe: 0u64,       sqe
+  - co_spawn:   handle(0),  available_sqe
+  - sem_rel:    task(1),    available_sqe
+  - cv_noti:    task(2),    available_sqe
+*/
 
-} // namespace detail
+/*
+- available:
+  - x,  available_sqe
+  - x,  available_sqe
+  - x,  available_sqe
+*/
 
-} // namespace co_context
+} // namespace co_context::detail

--- a/include/co_context/detail/swap_zone.hpp
+++ b/include/co_context/detail/swap_zone.hpp
@@ -9,68 +9,64 @@
 #include <cstring>
 #include <type_traits>
 
-namespace co_context {
+namespace co_context::detail {
 
-namespace detail {
+template<trival_ptr T>
+inline std::uintptr_t &as_uint(T &value) noexcept {
+    return *reinterpret_cast<uintptr_t *>(std::addressof(value));
+}
 
-    template<trival_ptr T>
-    inline std::uintptr_t &as_uint(T &value) noexcept {
-        return *reinterpret_cast<uintptr_t *>(std::addressof(value));
+template<trival_ptr T>
+inline const std::uintptr_t &as_uint(const T &value) noexcept {
+    return *reinterpret_cast<const uintptr_t *>(std::addressof(value));
+}
+
+template<typename T>
+    requires std::is_trivially_copyable_v<T>
+struct worker_swap_zone final {
+    using sz_t = config::swap_capacity_size_t;
+    using cur_t = ::co_context::spsc_cursor<sz_t, config::swap_capacity>;
+
+    T data[config::swap_capacity];
+
+    worker_swap_zone() noexcept = default;
+
+    worker_swap_zone(const worker_swap_zone &) = delete;
+    worker_swap_zone(worker_swap_zone &&) = delete;
+
+    T operator[](sz_t i) const noexcept { return data[i]; }
+
+    T &operator[](sz_t i) noexcept { return data[i]; }
+
+    inline void push(cur_t &cur, T value) noexcept {
+        data[cur.tail()] = value;
+        cur.push(1);
     }
 
-    template<trival_ptr T>
-    inline const std::uintptr_t &as_uint(const T &value) noexcept {
-        return *reinterpret_cast<const uintptr_t *>(std::addressof(value));
+    inline void push_notify(cur_t &cur, T value) noexcept {
+        data[cur.tail()] = value;
+        cur.push_notify(1);
     }
 
-    template<typename T>
-        requires std::is_trivially_copyable_v<T>
-    struct worker_swap_zone final {
-        using sz_t = config::swap_capacity_size_t;
-        using cur_t = ::co_context::spsc_cursor<sz_t, config::swap_capacity>;
+    inline T front(const cur_t &cur) const noexcept {
+        return data[cur.load_head()];
+    }
+};
 
-        T data[config::swap_capacity];
+template<typename T>
+    requires std::is_trivially_copyable_v<T>
+struct swap_zone final {
+    using sz_t = config::tid_t;
 
-        worker_swap_zone() noexcept = default;
+    worker_swap_zone<T> data[config::workers_number];
 
-        worker_swap_zone(const worker_swap_zone &) = delete;
-        worker_swap_zone(worker_swap_zone &&) = delete;
+    swap_zone() noexcept = default;
+    swap_zone(const swap_zone &) = delete;
+    swap_zone(swap_zone &&) = delete;
 
-        T operator[](sz_t i) const noexcept { return data[i]; }
+    auto &operator[](sz_t i) noexcept { return data[i]; }
 
-        T &operator[](sz_t i) noexcept { return data[i]; }
+    const auto &operator[](sz_t i) const noexcept { return data[i]; }
+};
 
-        inline void push(cur_t &cur, T value) noexcept {
-            data[cur.tail()] = value;
-            cur.push(1);
-        }
-
-        inline void push_notify(cur_t &cur, T value) noexcept {
-            data[cur.tail()] = value;
-            cur.push_notify(1);
-        }
-
-        inline T front(const cur_t &cur) const noexcept {
-            return data[cur.load_head()];
-        }
-    };
-
-    template<typename T>
-        requires std::is_trivially_copyable_v<T>
-    struct swap_zone final {
-        using sz_t = config::tid_t;
-
-        worker_swap_zone<T> data[config::workers_number];
-
-        swap_zone() noexcept = default;
-        swap_zone(const swap_zone &) = delete;
-        swap_zone(swap_zone &&) = delete;
-
-        auto &operator[](sz_t i) noexcept { return data[i]; }
-
-        const auto &operator[](sz_t i) const noexcept { return data[i]; }
-    };
-
-} // namespace detail
-
-} // namespace co_context
+} // namespace co_context::detail

--- a/include/co_context/detail/task_info.hpp
+++ b/include/co_context/detail/task_info.hpp
@@ -9,74 +9,74 @@ namespace co_context {
 class counting_semaphore;
 class condition_variable;
 
-namespace detail {
+} // namespace co_context
 
-    // using liburingcxx::sq_entry;
-    // using liburingcxx::cq_entry;
+namespace co_context::detail {
 
-    struct [[nodiscard]] task_info {
-        union {
-            std::coroutine_handle<> handle;
-            config::semaphore_counting_t update;
-            config::condition_variable_counting_t notify_counter;
-        };
+// using liburingcxx::sq_entry;
+// using liburingcxx::cq_entry;
 
-        union {
-            // const cq_entry *cqe;
-            int32_t result;
-            // counting_semaphore *sem;
-            // condition_variable *cv;
-        };
-
-        union {
-            config::tid_t tid_hint;
-            config::eager_io_state_t eager_io_state; // for eager_io
-        };
-
-        enum class task_type : uint8_t {
-            co_spawn,
-            eager_sqe,
-            lazy_sqe,
-            lazy_link_sqe,
-            // lazy_detached_sqe,
-            // result,
-            semaphore_release,
-            condition_variable_notify,
-            nop
-        };
-
-        task_type type;
-
-        task_info(task_type type) noexcept : type(type) {
-            log::v("task_info generated at %lx\n", this);
-        }
-
-        uint64_t as_user_data() const noexcept {
-            return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(this));
-        }
-
-        uint64_t as_eager_user_data() const noexcept {
-            return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(this))
-                   | uint64_t(task_type::eager_sqe);
-        }
-
-        [[deprecated]] uint64_t as_linked_user_data() const noexcept {
-            return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(this))
-                   | uint64_t(task_type::lazy_link_sqe);
-        }
+struct [[nodiscard]] task_info {
+    union {
+        std::coroutine_handle<> handle;
+        config::semaphore_counting_t update;
+        config::condition_variable_counting_t notify_counter;
     };
 
-    static_assert(uint8_t(task_info::task_type::nop) < alignof(task_info));
+    union {
+        // const cq_entry *cqe;
+        int32_t result;
+        // counting_semaphore *sem;
+        // condition_variable *cv;
+    };
 
-    inline constexpr uintptr_t raw_task_info_mask =
-        ~uintptr_t(alignof(task_info) - 1);
+    union {
+        config::tid_t tid_hint;
+        config::eager_io_state_t eager_io_state; // for eager_io
+    };
 
-    static_assert((~raw_task_info_mask) == 0x7);
+    enum class task_type : uint8_t {
+        co_spawn,
+        eager_sqe,
+        lazy_sqe,
+        lazy_link_sqe,
+        // lazy_detached_sqe,
+        // result,
+        semaphore_release,
+        condition_variable_notify,
+        nop
+    };
 
-    inline task_info *raw_task_info_ptr(uintptr_t info) noexcept {
-        return reinterpret_cast<task_info *>(info & raw_task_info_mask);
+    task_type type;
+
+    explicit task_info(task_type type) noexcept : type(type) {
+        log::v("task_info generated at %lx\n", this);
     }
 
-} // namespace detail
+    [[nodiscard]] uint64_t as_user_data() const noexcept {
+        return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(this));
+    }
 
-} // namespace co_context
+    [[nodiscard]] uint64_t as_eager_user_data() const noexcept {
+        return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(this))
+               | uint64_t(task_type::eager_sqe);
+    }
+
+    [[deprecated, nodiscard]] uint64_t as_linked_user_data() const noexcept {
+        return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(this))
+               | uint64_t(task_type::lazy_link_sqe);
+    }
+};
+
+static_assert(uint8_t(task_info::task_type::nop) < alignof(task_info));
+
+inline constexpr uintptr_t raw_task_info_mask =
+    ~uintptr_t(alignof(task_info) - 1);
+
+static_assert((~raw_task_info_mask) == 0x7);
+
+inline task_info *raw_task_info_ptr(uintptr_t info) noexcept {
+    return /*NOLINT*/ reinterpret_cast<task_info *>(info & raw_task_info_mask);
+}
+
+} // namespace co_context::detail

--- a/include/co_context/detail/thread_meta.hpp
+++ b/include/co_context/detail/thread_meta.hpp
@@ -6,18 +6,18 @@ namespace co_context {
 
 class io_context;
 
-namespace detail {
-
-    struct worker_meta;
-
-    struct alignas(config::cache_line_size) thread_meta {
-        io_context *ctx;
-        worker_meta *worker;
-        config::tid_t tid;
-    };
-
-    extern thread_local thread_meta this_thread;
-
-} // namespace detail
-
 } // namespace co_context
+
+namespace co_context::detail {
+
+struct worker_meta;
+
+struct alignas(config::cache_line_size) thread_meta {
+    io_context *ctx;
+    worker_meta *worker;
+    config::tid_t tid;
+};
+
+extern thread_local thread_meta this_thread;
+
+} // namespace co_context::detail

--- a/include/co_context/detail/worker_meta.hpp
+++ b/include/co_context/detail/worker_meta.hpp
@@ -14,88 +14,86 @@ namespace co_context {
 
 class io_context;
 
-namespace detail {
+} // namespace co_context
 
-    struct worker_meta final {
-        using cur_t = config::cur_t;
+namespace co_context::detail {
 
-        /**
-         * @brief sharing zone with main thread
-         */
-        struct sharing_zone {
-            alignas(config::cache_line_size
-            ) spsc_cursor<cur_t, config::swap_capacity> submit_cur;
+struct worker_meta final {
+    using cur_t = config::cur_t;
 
-            alignas(config::cache_line_size
-            ) worker_swap_zone<detail::submit_info> submit_swap;
+    /**
+     * @brief sharing zone with main thread
+     */
+    struct sharing_zone {
+        alignas(config::cache_line_size
+        ) spsc_cursor<cur_t, config::swap_capacity> submit_cur;
 
-            alignas(config::cache_line_size
-            ) spsc_cursor<cur_t, config::swap_capacity> reap_cur;
+        alignas(config::cache_line_size
+        ) worker_swap_zone<detail::submit_info> submit_swap;
 
-            alignas(config::cache_line_size
-            ) worker_swap_zone<detail::reap_info> reap_swap;
-        };
+        alignas(config::cache_line_size
+        ) spsc_cursor<cur_t, config::swap_capacity> reap_cur;
 
-        using tid_t = config::threads_number_size_t;
-
-        alignas(config::cache_line_size) sharing_zone sharing;
-
-        alignas(config::cache_line_size) io_context *ctx = nullptr;
-        cur_t local_submit_tail = 0;
-        tid_t tid;
-        std::thread host_thread;
-        /*
-        std::queue<submit_info> submit_overflow_buf;
-        */
-
-        liburingcxx::sq_entry *get_free_sqe() noexcept;
-
-        [[deprecated]] void swap_last_two_sqes() noexcept;
-
-        void submit_sqe() noexcept;
-
-        void submit_non_sqe(uintptr_t typed_task) noexcept;
-
-        /*
-        void try_clear_submit_overflow_buf() noexcept;
-        */
-
-        std::coroutine_handle<> schedule() noexcept;
-
-        cur_t number_to_schedule_relaxed() const noexcept {
-            const auto &cur = this->sharing.reap_cur;
-            return cur.size();
-        }
-
-        std::coroutine_handle<> try_schedule() noexcept;
-
-        void init(int thread_index, io_context *context);
-
-        void co_spawn(task<void> &&entrance) noexcept;
-
-        void co_spawn(std::coroutine_handle<> entrance) noexcept;
-
-        void worker_run_loop(int thread_index, io_context *context);
-
-        void worker_run_once();
+        alignas(config::cache_line_size
+        ) worker_swap_zone<detail::reap_info> reap_swap;
     };
 
-    inline void worker_meta::co_spawn(std::coroutine_handle<> entrance
-    ) noexcept {
-        assert(entrance.address() != nullptr);
-        log::v(
-            "worker[%u] co_spawn coro %lx\n", this_thread.tid,
-            entrance.address()
-        );
-        this->submit_non_sqe(reinterpret_cast<uintptr_t>(entrance.address()));
+    using tid_t = config::threads_number_size_t;
+
+    alignas(config::cache_line_size) sharing_zone sharing;
+
+    alignas(config::cache_line_size) io_context *ctx = nullptr;
+    cur_t local_submit_tail = 0;
+    tid_t tid;
+    std::thread host_thread;
+    /*
+    std::queue<submit_info> submit_overflow_buf;
+    */
+
+    liburingcxx::sq_entry *get_free_sqe() noexcept;
+
+    [[deprecated]] void swap_last_two_sqes() noexcept;
+
+    void submit_sqe() noexcept;
+
+    void submit_non_sqe(uintptr_t typed_task) noexcept;
+
+    /*
+    void try_clear_submit_overflow_buf() noexcept;
+    */
+
+    std::coroutine_handle<> schedule() noexcept;
+
+    [[nodiscard]] cur_t number_to_schedule_relaxed() const noexcept {
+        const auto &cur = this->sharing.reap_cur;
+        return cur.size();
     }
 
-    inline void worker_meta::co_spawn(task<void> &&entrance) noexcept {
-        assert(entrance.get_handle().address() != nullptr);
-        this->co_spawn(entrance.get_handle());
-        entrance.detach();
-    }
+    std::coroutine_handle<> try_schedule() noexcept;
 
-} // namespace detail
+    void init(int thread_index, io_context *context);
 
-} // namespace co_context
+    void co_spawn(task<void> &&entrance) noexcept;
+
+    void co_spawn(std::coroutine_handle<> entrance) noexcept;
+
+    void worker_run_loop(int thread_index, io_context *context);
+
+    void worker_run_once();
+};
+
+inline void worker_meta::co_spawn(std::coroutine_handle<> entrance) noexcept {
+    assert(entrance.address() != nullptr);
+    log::v(
+        "worker[%u] co_spawn coro %lx\n", this_thread.tid, entrance.address()
+    );
+    this->submit_non_sqe(reinterpret_cast<uintptr_t>(entrance.address()));
+}
+
+inline void worker_meta::co_spawn(task<void> &&entrance) noexcept {
+    assert(entrance.get_handle().address() != nullptr);
+    this->co_spawn(entrance.get_handle());
+    entrance.detach();
+}
+
+} // namespace co_context::detail

--- a/include/co_context/io_context.hpp
+++ b/include/co_context/io_context.hpp
@@ -66,7 +66,7 @@ class [[nodiscard]] io_context final {
     alignas(cache_line_size) uring ring;
 
     // The meta data of worker(s)
-    alignas(cache_line_size) worker_meta worker[config::workers_number];
+    alignas(cache_line_size) worker_meta workers[config::workers_number];
 
     /**
      * ---------------------------------------------------
@@ -232,7 +232,9 @@ class [[nodiscard]] io_context final {
         init();
     }
 
-    io_context(unsigned io_uring_entries = config::default_io_uring_entries)
+    explicit io_context(
+        unsigned io_uring_entries = config::default_io_uring_entries
+    )
         : ring(io_uring_entries)
         , sqring_entries(io_uring_entries) {
         init();
@@ -253,9 +255,9 @@ class [[nodiscard]] io_context final {
 
     ~io_context() noexcept {
         for (int i = 0; i < config::worker_threads_number; ++i) {
-            std::thread &t = worker[i].host_thread;
-            if (t.joinable()) {
-                t.join();
+            std::thread &worker_thread = workers[i].host_thread;
+            if (worker_thread.joinable()) {
+                worker_thread.join();
             }
         }
     }

--- a/include/co_context/lockfree/spsc_cursor.hpp
+++ b/include/co_context/lockfree/spsc_cursor.hpp
@@ -18,27 +18,29 @@ struct spsc_cursor {
     T m_head = 0;
     T m_tail = 0;
 
-    inline T head() const noexcept { return m_head & mask; }
+    [[nodiscard]] inline T head() const noexcept { return m_head & mask; }
 
-    inline T tail() const noexcept { return m_tail & mask; }
+    [[nodiscard]] inline T tail() const noexcept { return m_tail & mask; }
 
-    inline T raw_head() const noexcept { return m_head; }
+    [[nodiscard]] inline T raw_head() const noexcept { return m_head; }
 
-    inline T raw_tail() const noexcept { return m_tail; }
+    [[nodiscard]] inline T raw_tail() const noexcept { return m_tail; }
 
-    inline bool is_empty() const noexcept { return m_head == m_tail; }
+    [[nodiscard]] inline bool is_empty() const noexcept {
+        return m_head == m_tail;
+    }
 
-    inline T size() const noexcept { return m_tail - m_head; }
+    [[nodiscard]] inline T size() const noexcept { return m_tail - m_head; }
 
-    inline T available_number() const noexcept {
+    [[nodiscard]] inline T available_number() const noexcept {
         return capacity - (m_tail - m_head);
     }
 
-    inline bool is_available() const noexcept {
+    [[nodiscard]] inline bool is_available() const noexcept {
         return bool(capacity - (m_tail - m_head));
     }
 
-    inline T load_head() const noexcept {
+    [[nodiscard]] inline T load_head() const noexcept {
         if constexpr (need_thread_safe) {
             return as_c_atomic(m_head).load(std::memory_order_acquire) & mask;
         } else {
@@ -46,7 +48,7 @@ struct spsc_cursor {
         }
     }
 
-    inline T load_tail() const noexcept {
+    [[nodiscard]] inline T load_tail() const noexcept {
         if constexpr (need_thread_safe) {
             return as_c_atomic(m_tail).load(std::memory_order_acquire) & mask;
         } else {
@@ -54,7 +56,7 @@ struct spsc_cursor {
         }
     }
 
-    inline T load_raw_head() const noexcept {
+    [[nodiscard]] inline T load_raw_head() const noexcept {
         if constexpr (need_thread_safe) {
             return as_c_atomic(m_head).load(std::memory_order_acquire);
         } else {
@@ -62,7 +64,7 @@ struct spsc_cursor {
         }
     }
 
-    inline T load_raw_tail() const noexcept {
+    [[nodiscard]] inline T load_raw_tail() const noexcept {
         if constexpr (need_thread_safe) {
             return as_c_atomic(m_tail).load(std::memory_order_acquire);
         } else {
@@ -70,7 +72,7 @@ struct spsc_cursor {
         }
     }
 
-    inline T load_raw_tail_relaxed() const noexcept {
+    [[nodiscard]] inline T load_raw_tail_relaxed() const noexcept {
         if constexpr (need_thread_safe) {
             return as_c_atomic(m_tail).load(std::memory_order_relaxed);
         } else {
@@ -88,19 +90,19 @@ struct spsc_cursor {
         }
     }
 
-    inline bool is_empty_load_head() const noexcept {
+    [[nodiscard]] inline bool is_empty_load_head() const noexcept {
         return m_tail == load_raw_head();
     }
 
-    inline bool is_empty_load_tail() const noexcept {
+    [[nodiscard]] inline bool is_empty_load_tail() const noexcept {
         return m_head == load_raw_tail();
     }
 
-    inline bool is_empty_load_tail_relaxed() const noexcept {
+    [[nodiscard]] inline bool is_empty_load_tail_relaxed() const noexcept {
         return m_head == load_raw_tail_relaxed();
     }
 
-    inline bool is_available_load_head() const noexcept {
+    [[nodiscard]] inline bool is_available_load_head() const noexcept {
         return bool(capacity - (m_tail - load_raw_head()));
     }
 

--- a/include/co_context/lockfree/spsc_cursor.hpp
+++ b/include/co_context/lockfree/spsc_cursor.hpp
@@ -8,7 +8,7 @@ namespace co_context {
 
 template<std::unsigned_integral T, T capacity>
 struct spsc_cursor {
-    static_assert(is_pow_of_two(capacity));
+    static_assert(std::has_single_bit(capacity));
     // Check config::swap_capacity_size_t if this assertion fails.
     static_assert(std::atomic<T>::is_always_lock_free);
     inline static constexpr T mask = capacity - 1;

--- a/include/co_context/net/acceptor.hpp
+++ b/include/co_context/net/acceptor.hpp
@@ -15,15 +15,15 @@ class acceptor {
     acceptor(acceptor &&) = default;
     acceptor &operator=(acceptor &&) = default;
 
-    auto accept(int flags = 0) noexcept {
+    [[nodiscard]] auto accept(int flags = 0) noexcept {
         return lazy::accept(listen_socket.fd(), nullptr, nullptr, flags);
     }
 
-    auto eager_accept(int flags = 0) noexcept {
+    [[nodiscard]] auto eager_accept(int flags = 0) noexcept {
         return eager::accept(listen_socket.fd(), nullptr, nullptr, flags);
     }
 
-    int listen_fd() const noexcept { return listen_socket.fd(); }
+    [[nodiscard]] int listen_fd() const noexcept { return listen_socket.fd(); }
 
     // socket acceptSocketOrDie();
 

--- a/include/co_context/net/inet_address.hpp
+++ b/include/co_context/net/inet_address.hpp
@@ -25,30 +25,30 @@ class inet_address {
     /**
      * @brief for listening
      */
-    inet_address(uint16_t port, bool is_ipv6 = false) noexcept;
+    explicit inet_address(uint16_t port, bool is_ipv6 = false) noexcept;
 
     /**
      * @brief for Sockets API
      */
     explicit inet_address(const struct sockaddr &saddr) noexcept;
 
-    sa_family_t family() const noexcept { return addr.sin_family; }
+    [[nodiscard]] sa_family_t family() const noexcept { return addr.sin_family; }
 
-    uint16_t port() const noexcept { return ntohs(addr.sin_port); }
+    [[nodiscard]] uint16_t port() const noexcept { return ntohs(addr.sin_port); }
 
     inet_address &reset_port(uint16_t port) noexcept {
         addr.sin_port = htons(port);
         return *this;
     }
 
-    std::string to_ip() const;
-    std::string to_ip_port() const;
+    [[nodiscard]] std::string to_ip() const;
+    [[nodiscard]] std::string to_ip_port() const;
 
-    const struct sockaddr *get_sockaddr() const noexcept {
+    [[nodiscard]] const struct sockaddr *get_sockaddr() const noexcept {
         return reinterpret_cast<const struct sockaddr *>(&addr6);
     }
 
-    socklen_t length() const noexcept {
+    [[nodiscard]] socklen_t length() const noexcept {
         return family() == AF_INET6 ? sizeof(addr6) : sizeof(addr);
     }
 

--- a/include/co_context/net/socket.hpp
+++ b/include/co_context/net/socket.hpp
@@ -39,7 +39,7 @@ class socket {
         other.sockfd = tmp;
     }
 
-    int fd() const noexcept { return sockfd; }
+    [[nodiscard]] int fd() const noexcept { return sockfd; }
 
     socket &bind(const inet_address &addr);
 
@@ -49,51 +49,51 @@ class socket {
 
     socket &set_tcp_no_delay(bool on);
 
-    inet_address get_local_addr() const;
+    [[nodiscard]] inet_address get_local_addr() const;
 
-    inet_address get_peer_addr() const;
+    [[nodiscard]] inet_address get_peer_addr() const;
 
-    auto connect(const inet_address &addr) const noexcept {
+    [[nodiscard]] auto connect(const inet_address &addr) const noexcept {
         return lazy::connect(sockfd, addr.get_sockaddr(), addr.length());
     }
 
-    auto eager_connect(const inet_address &addr) const noexcept {
+    [[nodiscard]] auto eager_connect(const inet_address &addr) const noexcept {
         return eager::connect(sockfd, addr.get_sockaddr(), addr.length());
     }
 
-    auto recv(std::span<char> buf, int flags = 0) const noexcept {
+    [[nodiscard]] auto recv(std::span<char> buf, int flags = 0) const noexcept {
         return lazy::recv(sockfd, buf, flags);
     }
 
-    auto eager_recv(std::span<char> buf, int flags = 0) const noexcept {
+    [[nodiscard]] auto eager_recv(std::span<char> buf, int flags = 0) const noexcept {
         return eager::recv(sockfd, buf, flags);
     }
 
-    auto send(std::span<const char> buf, int flags = 0) const noexcept {
+    [[nodiscard]] auto send(std::span<const char> buf, int flags = 0) const noexcept {
         return lazy::send(sockfd, buf, flags);
     }
 
-    auto eager_send(std::span<const char> buf, int flags = 0) const noexcept {
+    [[nodiscard]] auto eager_send(std::span<const char> buf, int flags = 0) const noexcept {
         return eager::send(sockfd, buf, flags);
     }
 
-    auto close() noexcept {
+    [[nodiscard]] auto close() noexcept {
         const int tmp = sockfd;
         sockfd = -1;
         return lazy::close(tmp);
     }
 
-    auto eager_close() noexcept {
+    [[nodiscard]] auto eager_close() noexcept {
         const int tmp = sockfd;
         sockfd = -1;
         return eager::close(tmp);
     }
 
-    auto shutdown_write() const noexcept {
+    [[nodiscard]] auto shutdown_write() const noexcept {
         return lazy::shutdown(sockfd, SHUT_WR);
     }
 
-    auto eager_shutdown_write() const noexcept {
+    [[nodiscard]] auto eager_shutdown_write() const noexcept {
         return eager::shutdown(sockfd, SHUT_WR);
     }
 

--- a/include/co_context/task.hpp
+++ b/include/co_context/task.hpp
@@ -239,10 +239,10 @@ class [[nodiscard("Did you forget to co_await?")]] task {
     struct awaiter_base {
         std::coroutine_handle<promise_type> handle;
 
-        awaiter_base(std::coroutine_handle<promise_type> current) noexcept
+        explicit awaiter_base(std::coroutine_handle<promise_type> current) noexcept
             : handle(current) {}
 
-        inline bool await_ready() const noexcept {
+        [[nodiscard]] inline bool await_ready() const noexcept {
             return !handle || handle.done();
         }
 
@@ -286,7 +286,7 @@ class [[nodiscard("Did you forget to co_await?")]] task {
         }
     }
 
-    inline bool is_ready() const noexcept {
+    [[nodiscard]] inline bool is_ready() const noexcept {
         return !handle || handle.done();
     }
 
@@ -332,7 +332,7 @@ class [[nodiscard("Did you forget to co_await?")]] task {
     /**
      * @brief wait for the task<> to complete, but do not get the result
      */
-    auto when_ready() const noexcept {
+    [[nodiscard]] auto when_ready() const noexcept {
         struct awaiter : awaiter_base {
             using awaiter_base::awaiter_base;
 

--- a/include/co_context/utility/bit.hpp
+++ b/include/co_context/utility/bit.hpp
@@ -6,19 +6,12 @@
 
 namespace co_context {
 
-template<std::integral T>
-consteval T bit_top() noexcept {
-    return T(-1) ^ (T(-1) >> 1);
-}
+template<std::unsigned_integral T>
+inline constexpr T bit_top = T(-1) ^ (T(-1) >> 1);
 
 template<std::integral T>
 inline constexpr T lowbit(T x) noexcept {
     return x & (-x);
-}
-
-template<std::integral T>
-inline constexpr bool is_pow_of_two(T x) noexcept {
-    return lowbit(x) == x;
 }
 
 template<typename T>

--- a/include/co_context/utility/polymorphism.hpp
+++ b/include/co_context/utility/polymorphism.hpp
@@ -13,7 +13,7 @@ overloaded(F...) -> overloaded<F...>;
 
 // CRTP
 template<typename T, template<typename> class Interface>
-struct CRTP {
+struct CRTP /*NOLINT*/ {
     T &self() { return static_cast<T &>(*this); }
 
     const T &self() const { return static_cast<const T &>(*this); }

--- a/include/uring/buf_ring.hpp
+++ b/include/uring/buf_ring.hpp
@@ -14,22 +14,18 @@ class buf_ring final : private io_uring_buf_ring {
     inline void init() noexcept { this->tail = 0; }
 
     inline void
-    add(void *addr,
-        unsigned int len,
-        unsigned short bid,
-        int mask,
-        int buf_offset) noexcept {
+    add(void *addr, unsigned int len, uint16_t bid, int mask, int buf_offset
+    ) noexcept {
         const int index = (this->tail + buf_offset) & mask;
 
         io_uring_buf *const buf = this->bufs + index;
-        buf->addr =
-            static_cast<unsigned long>(reinterpret_cast<uintptr_t>(addr));
+        buf->addr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(addr));
         buf->len = len;
         buf->bid = bid;
     }
 
     inline void advance(int count) noexcept {
-        const unsigned short new_tail = this->tail + count;
+        const uint16_t new_tail = this->tail + count;
         io_uring_smp_store_release(&this->tail, new_tail);
     }
 

--- a/include/uring/buf_ring.hpp
+++ b/include/uring/buf_ring.hpp
@@ -6,7 +6,7 @@
 
 namespace liburingcxx {
 
-template<unsigned uring_flags>
+template<uint64_t uring_flags>
 class uring;
 
 class buf_ring final : private io_uring_buf_ring {
@@ -39,7 +39,7 @@ class buf_ring final : private io_uring_buf_ring {
     }
 
   public:
-    template<unsigned uring_flags>
+    template<uint64_t uring_flags>
     friend class ::liburingcxx::uring;
 };
 

--- a/include/uring/detail/cq.hpp
+++ b/include/uring/detail/cq.hpp
@@ -4,7 +4,7 @@
 
 namespace liburingcxx {
 
-template<unsigned uring_flags>
+template<uint64_t uring_flags>
 class uring;
 
 namespace detail {
@@ -43,7 +43,7 @@ namespace detail {
         }
 
       public:
-        template<unsigned uring_flags>
+        template<uint64_t uring_flags>
         friend class ::liburingcxx::uring;
         completion_queue() noexcept = default;
         ~completion_queue() noexcept = default;

--- a/include/uring/detail/cq.hpp
+++ b/include/uring/detail/cq.hpp
@@ -30,6 +30,7 @@ namespace detail {
 
       private:
         void set_offset(const io_cqring_offsets &off) noexcept {
+            // NOLINTBEGIN
             khead = (unsigned *)((uintptr_t)ring_ptr + off.head);
             ktail = (unsigned *)((uintptr_t)ring_ptr + off.tail);
             ring_mask = *(unsigned *)((uintptr_t)ring_ptr + off.ring_mask);
@@ -40,6 +41,7 @@ namespace detail {
             }
             koverflow = (unsigned *)((uintptr_t)ring_ptr + off.overflow);
             cqes = (cq_entry *)((uintptr_t)ring_ptr + off.cqes);
+            // NOLINTEND
         }
 
       public:

--- a/include/uring/detail/sq.hpp
+++ b/include/uring/detail/sq.hpp
@@ -7,7 +7,7 @@
 
 namespace liburingcxx {
 
-template<unsigned uring_flags>
+template<uint64_t uring_flags>
 class uring;
 
 namespace detail {
@@ -57,7 +57,7 @@ namespace detail {
          * @return unsigned number of pending items in the SQ ring, for the
          * shared ring.
          */
-        template<unsigned uring_flags>
+        template<uint64_t uring_flags>
         unsigned flush() noexcept {
             if (sqe_tail != sqe_head) [[likely]] {
                 /*
@@ -94,7 +94,7 @@ namespace detail {
          * @brief Returns number of unconsumed (if SQPOLL) or unsubmitted
          * entries exist in the SQ ring
          */
-        template<unsigned uring_flags>
+        template<uint64_t uring_flags>
         inline unsigned pending() const noexcept {
             /*
              * Without a barrier, we could miss an update and think the SQ
@@ -131,7 +131,7 @@ namespace detail {
          * The sqes from sqe_free_head(included) to khead(not included) are all
          * free and available for application.
          */
-        template<unsigned uring_flags>
+        template<uint64_t uring_flags>
         [[nodiscard]] inline sq_entry *get_sq_entry() noexcept {
             constexpr int shift =
                 bool(uring_flags & IORING_SETUP_SQE128) ? 1 : 0;
@@ -156,7 +156,7 @@ namespace detail {
         }
 
       public:
-        template<unsigned uring_flags>
+        template<uint64_t uring_flags>
         friend class ::liburingcxx::uring;
         submission_queue() noexcept = default;
         ~submission_queue() noexcept = default;

--- a/include/uring/detail/sq.hpp
+++ b/include/uring/detail/sq.hpp
@@ -37,6 +37,7 @@ namespace detail {
 
       private:
         void set_offset(const io_sqring_offsets &off) noexcept {
+            // NOLINTBEGIN
             khead = (unsigned *)((uintptr_t)ring_ptr + off.head);
             ktail = (unsigned *)((uintptr_t)ring_ptr + off.tail);
             ring_mask = *(unsigned *)((uintptr_t)ring_ptr + off.ring_mask);
@@ -45,6 +46,7 @@ namespace detail {
             kflags = (unsigned *)((uintptr_t)ring_ptr + off.flags);
             kdropped = (unsigned *)((uintptr_t)ring_ptr + off.dropped);
             array = (unsigned *)((uintptr_t)ring_ptr + off.array);
+            // NOLINTEND
         }
 
         void init_free_queue() noexcept {
@@ -95,7 +97,7 @@ namespace detail {
          * entries exist in the SQ ring
          */
         template<uint64_t uring_flags>
-        inline unsigned pending() const noexcept {
+        [[nodiscard]] inline unsigned pending() const noexcept {
             /*
              * Without a barrier, we could miss an update and think the SQ
              * wasn't ready. We don't need the load acquire for non-SQPOLL since

--- a/include/uring/sq_entry.hpp
+++ b/include/uring/sq_entry.hpp
@@ -495,7 +495,7 @@ class sq_entry final : private io_uring_sqe {
 
     inline sq_entry &
     prep_send_set_addr(const sockaddr *dest_addr, uint16_t addr_len) {
-        this->addr2 = reinterpret_cast<unsigned long>(dest_addr);
+        this->addr2 = reinterpret_cast<uint64_t>(dest_addr);
         this->addr_len = addr_len;
         return *this;
     }

--- a/include/uring/sq_entry.hpp
+++ b/include/uring/sq_entry.hpp
@@ -16,12 +16,12 @@ struct statx;
 
 namespace liburingcxx {
 
-template<unsigned uring_flags>
+template<uint64_t uring_flags>
 class uring;
 
 class sq_entry final : private io_uring_sqe {
   public:
-    template<unsigned uring_flags>
+    template<uint64_t uring_flags>
     friend class ::liburingcxx::uring;
 
     inline sq_entry &clone_from(const sq_entry &other) noexcept {

--- a/include/uring/uring_define.hpp
+++ b/include/uring/uring_define.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+namespace liburingcxx {
+
+enum uring_setup : uint64_t {
+    // from (1ULL << 32) to (1ULL << 63)
+    sqe_reorder = 1ULL << 32
+};
+
+} // namespace liburingcxx

--- a/include/uring/utility/io_helper.hpp
+++ b/include/uring/utility/io_helper.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "../io_uring.h"
-#include <sys/socket.h>
+#include <cstdint>
 #include <span>
+#include <sys/socket.h>
 
 namespace liburingcxx {
 
@@ -58,10 +59,10 @@ static inline void *recvmsg_payload(io_uring_recvmsg_out *o, msghdr *msgh) {
 
 static inline unsigned int
 recvmsg_payload_length(io_uring_recvmsg_out *o, int buf_len, msghdr *msgh) {
-    unsigned long payload_start, payload_end;
+    uint64_t payload_start, payload_end;
 
-    payload_start = (unsigned long)recvmsg_payload(o, msgh);
-    payload_end = (unsigned long)o + buf_len;
+    payload_start = (uint64_t)recvmsg_payload(o, msgh);
+    payload_end = (uint64_t)o + buf_len;
     return (unsigned int)(payload_end - payload_start);
 }
 

--- a/include/uring/utility/kernel_version.hpp
+++ b/include/uring/utility/kernel_version.hpp
@@ -20,6 +20,6 @@ consteval bool is_kernel_reach(int major, int patchlevel) noexcept {
 } // namespace liburingcxx
 
 #define LIBURINGCXX_IS_KERNEL_REACH(major, patchlevel) \
-    (LIBURINGCXX_KERNEL_VERSION_MAJOR > major)         \
-        || (LIBURINGCXX_KERNEL_VERSION_MAJOR == major  \
-            && LIBURINGCXX_KERNEL_VERSION_PATCHLEVEL >= patchlevel)
+    ((LIBURINGCXX_KERNEL_VERSION_MAJOR > (major))      \
+     || (LIBURINGCXX_KERNEL_VERSION_MAJOR == (major)   \
+         && LIBURINGCXX_KERNEL_VERSION_PATCHLEVEL >= (patchlevel)))


### PR DESCRIPTION
- continue to refactor the code according to clang-tidy.
- force to be compiled by g++ 11.3 or above.
- extend `uring_flags` to 64 bits for further development.