### PR TITLE
Feat: More accurate timer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-project(co_context VERSION 0.8.1 LANGUAGES CXX)
+project(co_context VERSION 0.8.2 LANGUAGES CXX)
 
 if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     message(WARNING "co_context only supports Linux currently, but the target OS is ${CMAKE_SYSTEM_NAME}.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-project(co_context VERSION 0.8.0 LANGUAGES CXX)
+project(co_context VERSION 0.8.1 LANGUAGES CXX)
 
 if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     message(WARNING "co_context only supports Linux currently, but the target OS is ${CMAKE_SYSTEM_NAME}.")

--- a/include/co_context/config.hpp
+++ b/include/co_context/config.hpp
@@ -120,6 +120,19 @@ namespace config {
     inline constexpr bool enable_link_io_result = false;
     // ========================================================================
 
+    // ========================= timer configuration ==========================
+    /**
+     * @brief Fix the timer expiring time point, to improve accuracy.
+     * E.g. timeout(time) => timeout(time + bias);
+     * @note The accuracy of the timer is mainly limited by the OS. The actual
+     * time is usually 20~500 microseconds later than the scheduled time.
+     * @warning If it is more important to ensure that no network signal is
+     * missed than to ensure accuracy, it is recommended to set bias to 0.
+     */
+    // inline constexpr int64_t timeout_bias_nanosecond = 0;
+    inline constexpr int64_t timeout_bias_nanosecond = -60'000;
+    // ========================================================================
+
 } // namespace config
 
 // logging config

--- a/include/co_context/detail/lazy_io_awaiter.hpp
+++ b/include/co_context/detail/lazy_io_awaiter.hpp
@@ -303,12 +303,7 @@ inline constexpr uint32_t timeout_relative_flag = 0
 #endif
     ;
 
-inline constexpr uint32_t timeout_absolute_steady_flag =
-    IORING_TIMEOUT_ABS
-#if LIBURINGCXX_IS_KERNEL_REACH(5, 15)
-    | IORING_TIMEOUT_BOOTTIME
-#endif
-    ;
+inline constexpr uint32_t timeout_absolute_steady_flag = IORING_TIMEOUT_ABS;
 
 inline constexpr uint32_t timeout_absolute_realtime_flag =
     IORING_TIMEOUT_ABS | IORING_TIMEOUT_REALTIME;

--- a/include/co_context/detail/lazy_io_awaiter.hpp
+++ b/include/co_context/detail/lazy_io_awaiter.hpp
@@ -271,21 +271,21 @@ struct lazy_timeout_base : lazy_awaiter {
   public:
     template<class Rep, class Period>
     void set_ts(std::chrono::duration<Rep, Period> duration) noexcept {
-        ts = to_kernel_timespec(duration);
+        ts = to_kernel_timespec_biased(duration);
     }
 
     template<class Duration>
     void set_ts(
         std::chrono::time_point<std::chrono::steady_clock, Duration> time_point
     ) noexcept {
-        ts = to_kernel_timespec(time_point);
+        ts = to_kernel_timespec_biased(time_point);
     }
 
     template<class Duration>
     void set_ts(
         std::chrono::time_point<std::chrono::system_clock, Duration> time_point
     ) noexcept {
-        ts = to_kernel_timespec(time_point);
+        ts = to_kernel_timespec_biased(time_point);
     }
 
     template<class Expire>

--- a/include/co_context/utility/time_cast.hpp
+++ b/include/co_context/utility/time_cast.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "co_context/config.hpp"
 #include <chrono>
 #include <linux/time_types.h>
 
@@ -34,6 +35,18 @@ inline __kernel_timespec to_kernel_timespec(
     std::chrono::time_point<std::chrono::system_clock, Duration> time_point
 ) {
     return to_kernel_timespec(time_point.time_since_epoch());
+}
+
+template<class Timespec>
+[[nodiscard]]
+inline __kernel_timespec to_kernel_timespec_biased(Timespec timespec) {
+    if constexpr (config::timeout_bias_nanosecond == 0) {
+        return to_kernel_timespec(timespec);
+    } else {
+        constexpr auto bias =
+            std::chrono::nanoseconds{config::timeout_bias_nanosecond};
+        return to_kernel_timespec(timespec + bias);
+    }
 }
 
 } // namespace co_context

--- a/test/timer_accuracy.cpp
+++ b/test/timer_accuracy.cpp
@@ -1,0 +1,22 @@
+#include "co_context/io_context.hpp"
+#include "co_context/lazy_io.hpp"
+#include <chrono>
+using namespace co_context;
+
+task<> cycle_abs(int sec) {
+    auto next = std::chrono::steady_clock::now();
+    while (true) {
+        next = next + std::chrono::seconds{sec};
+        co_await timeout_at(next);
+        auto late = std::chrono::steady_clock::now() - next;
+        printf("late = %ld ns\n", late.count());
+    }
+}
+
+int main() {
+    io_context ctx;
+    ctx.co_spawn(cycle_abs(1));
+    ctx.start();
+    ctx.join();
+    return 0;
+}


### PR DESCRIPTION
- Improve accuracy of timers using bias. (See config.hpp)
- Add test for the accuracy of timers.
- Do not use `CLOCK_BOOTTIME` time source for abs timers