### PR TITLE
Feat: add `detach` to lazy_io

### DIFF
--- a/example/echo_server.cpp
+++ b/example/echo_server.cpp
@@ -4,11 +4,13 @@ using namespace co_context;
 task<> session(int sockfd) {
     co_context::socket sock{sockfd};
     char buf[8192];
+    int nr = co_await sock.recv(buf);
 
-    while (true) {
-        int nr = co_await sock.recv(buf);
-        co_await sock.send({buf, (size_t)nr});
+    while (nr > 0) {
+        nr = co_await (sock.send({buf, (size_t)nr}) && sock.recv(buf));
     }
+
+    sock.close().detach();
 }
 
 task<> server(const uint16_t port) {

--- a/example/echo_server_MT.cpp
+++ b/example/echo_server_MT.cpp
@@ -14,6 +14,8 @@ task<> session(int sockfd) {
     while (nr > 0) {
         nr = co_await (sock.send({buf, (size_t)nr}) && sock.recv(buf));
     }
+
+    sock.close().detach();
 }
 
 task<> server(const uint16_t port) {

--- a/example/netcat_timeout.cpp
+++ b/example/netcat_timeout.cpp
@@ -25,6 +25,7 @@ task<> session(Socket sock) {
         nr = co_await timeout(sock.recv(buf), 3s);
     }
 
+    sock.close().detach();
     if (nr < 0) {
         log_error(-nr);
     }

--- a/example/redis_echo.cpp
+++ b/example/redis_echo.cpp
@@ -10,6 +10,7 @@ task<> reply(co_context::socket sock) {
     while (n > 0) {
         n = co_await (sock.send({"+OK\r\n", 5}) && sock.recv(recv_buf));
     }
+    sock.close().detach();
 }
 
 task<> server() {

--- a/example/redis_echo_MT.cpp
+++ b/example/redis_echo_MT.cpp
@@ -14,6 +14,7 @@ task<> reply(co_context::socket sock) {
     while (n > 0) {
         n = co_await (sock.send({"+OK\r\n", 5}) && sock.recv(recv_buf));
     }
+    sock.close().detach();
 }
 
 task<> server() {

--- a/include/co_context/detail/lazy_io_awaiter.hpp
+++ b/include/co_context/detail/lazy_io_awaiter.hpp
@@ -453,6 +453,7 @@ struct lazy_link_timeout
         return {};
     }
 
+  private:
     void arrange_io(lazy_awaiter &&timed_io) noexcept {
         // Mark timed_io as normal task type, but set sqe link.
         timed_io.sqe->set_link();
@@ -464,6 +465,7 @@ struct lazy_link_timeout
         this->last_io = &timed_io;
     }
 
+  public:
     template<class Rep, class Period>
     inline lazy_link_timeout(
         lazy_awaiter &&timed_io, std::chrono::duration<Rep, Period> duration

--- a/include/co_context/task.hpp
+++ b/include/co_context/task.hpp
@@ -93,6 +93,11 @@ namespace detail {
             parent_coro = continuation;
         }
 
+        task_promise_base(const task_promise_base &) = delete;
+        task_promise_base(task_promise_base &&) = delete;
+        task_promise_base &operator=(const task_promise_base &) = delete;
+        task_promise_base &operator=(task_promise_base &&) = delete;
+
       private:
         std::coroutine_handle<> parent_coro{std::noop_coroutine()};
     };
@@ -114,7 +119,7 @@ namespace detail {
                     break;
                 case value_state::exception:
                     exception_ptr.~exception_ptr();
-                    [[fallthrough]];
+                    break;
                 default:
                     break;
             }
@@ -356,6 +361,10 @@ class [[CO_CONTEXT_AWAIT_HINT]] task {
             handle.promise().is_detached_flag = promise_type::is_detached;
         }
         handle = nullptr;
+    }
+
+    friend void swap(task &a, task &b) noexcept {
+        std::swap(a.handle, b.handle);
     }
 
   private:

--- a/include/uring/sq_entry.hpp
+++ b/include/uring/sq_entry.hpp
@@ -80,6 +80,11 @@ class sq_entry final : private io_uring_sqe {
         this->flags |= IOSQE_CQE_SKIP_SUCCESS;
         return *this;
     }
+
+    [[nodiscard]]
+    inline bool is_cqe_skip() const noexcept {
+        return (this->flags & IOSQE_CQE_SKIP_SUCCESS);
+    }
 #endif
 
   private:


### PR DESCRIPTION
- lazy_io can be `detach`ed now. That means you don't care the result of the IO AND you don't want to wait for it. It is useful when you have to close a fd.