### PR TITLE
feat(uring): add openat2 compat

### DIFF
--- a/cmake/CompileOption.cmake
+++ b/cmake/CompileOption.cmake
@@ -18,20 +18,6 @@ if(CMAKE_BUILD_TYPE MATCHES Release)
     target_compile_options(co_context PUBLIC -march=native)
 endif()
 
-# Get the linux kernel version to liburingcxx
-message(STATUS "target_kernel_version = ${CMAKE_SYSTEM_VERSION}")
-set(kernel_version ${CMAKE_SYSTEM_VERSION})
-string(REGEX MATCH "^([0-9]+)\.([0-9]+)" kernel_version ${kernel_version})
-string(REGEX MATCH "^([0-9]+)" kernel_version_major ${kernel_version})
-string(REGEX REPLACE "^([0-9]+)\\." "" kernel_version_minor ${kernel_version})
-message(STATUS "kernel_version_major = ${kernel_version_major}")
-message(STATUS "kernel_version_minor = ${kernel_version_minor}")
-target_compile_definitions(co_context
-    PUBLIC "$<BUILD_INTERFACE:LIBURINGCXX_KERNEL_VERSION_MAJOR=${kernel_version_major}>"
-    PUBLIC "$<BUILD_INTERFACE:LIBURINGCXX_KERNEL_VERSION_MINOR=${kernel_version_minor}>"
-)
-unset(kernel_version)
-
 # Optional IPO/LTO.
 include(CheckIPOSupported)
 check_ipo_supported(RESULT is_support_IPO OUTPUT output_support_IPO)

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -1,4 +1,21 @@
 # ----------------------------------------------------------------------------
+#   Linux
+# ----------------------------------------------------------------------------
+# Get the linux kernel version to liburingcxx
+message(STATUS "target_kernel_version = ${CMAKE_SYSTEM_VERSION}")
+set(kernel_version ${CMAKE_SYSTEM_VERSION})
+string(REGEX MATCH "^([0-9]+)\.([0-9]+)" kernel_version ${kernel_version})
+string(REGEX MATCH "^([0-9]+)" kernel_version_major ${kernel_version})
+string(REGEX REPLACE "^([0-9]+)\\." "" kernel_version_minor ${kernel_version})
+message(STATUS "kernel_version_major = ${kernel_version_major}")
+message(STATUS "kernel_version_minor = ${kernel_version_minor}")
+target_compile_definitions(co_context
+    PUBLIC "$<BUILD_INTERFACE:LIBURINGCXX_KERNEL_VERSION_MAJOR=${kernel_version_major}>"
+    PUBLIC "$<BUILD_INTERFACE:LIBURINGCXX_KERNEL_VERSION_MINOR=${kernel_version_minor}>"
+)
+unset(kernel_version)
+
+# ----------------------------------------------------------------------------
 #   Gcc
 # ----------------------------------------------------------------------------
 

--- a/include/co_context/detail/lazy_io_awaiter.hpp
+++ b/include/co_context/detail/lazy_io_awaiter.hpp
@@ -630,12 +630,15 @@ struct lazy_recv_multishot : lazy_awaiter {
 };
 #endif
 
+#ifdef LIBURINGCXX_HAS_OPENAT2
 struct lazy_openat2 : lazy_awaiter {
     inline lazy_openat2(int dfd, const char *path, open_how *how) noexcept {
         sqe->prep_openat2(dfd, path, how);
     }
 };
+#endif
 
+#ifdef LIBURINGCXX_HAS_OPENAT2
 /* open directly into the fixed file table */
 struct lazy_openat2_direct : lazy_awaiter {
     inline lazy_openat2_direct(
@@ -644,6 +647,7 @@ struct lazy_openat2_direct : lazy_awaiter {
         sqe->prep_openat2_direct(dfd, path, how, file_index);
     }
 };
+#endif
 
 struct lazy_epoll_ctl : lazy_awaiter {
     inline lazy_epoll_ctl(int epfd, int fd, int op, epoll_event *ev) noexcept {

--- a/include/co_context/lazy_io.hpp
+++ b/include/co_context/lazy_io.hpp
@@ -425,18 +425,22 @@ inline namespace lazy {
     }
 #endif
 
+#ifdef LIBURINGCXX_HAS_OPENAT2
     [[CO_CONTEXT_AWAIT_HINT]]
     inline detail::lazy_openat2
     openat2(int dfd, const char *path, open_how *how) noexcept {
         return detail::lazy_openat2{dfd, path, how};
     }
+#endif
 
+#ifdef LIBURINGCXX_HAS_OPENAT2
     [[CO_CONTEXT_AWAIT_HINT]]
     inline detail::lazy_openat2_direct openat2_direct(
         int dfd, const char *path, open_how *how, unsigned int file_index
     ) noexcept {
         return detail::lazy_openat2_direct{dfd, path, how, file_index};
     }
+#endif
 
     [[CO_CONTEXT_AWAIT_HINT]]
     inline detail::lazy_epoll_ctl

--- a/include/uring/compat.h
+++ b/include/uring/compat.h
@@ -1,9 +1,0 @@
-/* SPDX-License-Identifier: MIT */
-#ifndef LIBURING_COMPAT_H
-#define LIBURING_COMPAT_H
-
-#include <linux/time_types.h>
-
-#include <linux/openat2.h>
-
-#endif

--- a/include/uring/compat.hpp
+++ b/include/uring/compat.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <linux/time_types.h>
+
+#if __has_include(<linux/openat2.h>)
+#include <linux/openat2.h>
+#define LIBURINGCXX_HAS_OPENAT2
+#endif

--- a/include/uring/sq_entry.hpp
+++ b/include/uring/sq_entry.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <uring/compat.h>
+#include <uring/compat.hpp>
 #include <uring/io_uring.h>
 #include <uring/utility/io_helper.hpp>
 #include <uring/utility/kernel_version.hpp>
@@ -559,6 +559,7 @@ class sq_entry final : private io_uring_sqe {
     }
 #endif
 
+#ifdef LIBURINGCXX_HAS_OPENAT2
     inline sq_entry &
     prep_openat2(int dfd, const char *path, struct open_how *how) noexcept {
         prep_rw(
@@ -566,7 +567,9 @@ class sq_entry final : private io_uring_sqe {
         );
         return *this;
     }
+#endif
 
+#ifdef LIBURINGCXX_HAS_OPENAT2
     /* open directly into the fixed file table */
     inline sq_entry &prep_openat2_direct(
         int dfd, const char *path, struct open_how *how, unsigned file_index
@@ -575,13 +578,16 @@ class sq_entry final : private io_uring_sqe {
         set_target_fixed_file(file_index);
         return *this;
     }
+#endif
 
+#ifdef LIBURINGCXX_HAS_OPENAT2
     /* open directly into the fixed file table */
     inline sq_entry &prep_openat2_direct_alloc(
         int dfd, const char *path, struct open_how *how
     ) noexcept {
         return prep_openat2_direct(dfd, path, how, IORING_FILE_INDEX_ALLOC - 1);
     }
+#endif
 
     inline sq_entry &
     prep_epoll_ctl(int epfd, int fd, int op, epoll_event *ev) noexcept {

--- a/include/uring/uring.hpp
+++ b/include/uring/uring.hpp
@@ -27,7 +27,7 @@
 
 #include <uring/barrier.h>
 #include <uring/buf_ring.hpp>
-#include <uring/compat.h>
+#include <uring/compat.hpp>
 #include <uring/cq_entry.hpp>
 #include <uring/detail/cq.hpp>
 #include <uring/detail/int_flags.h>

--- a/include/uring/utility/kernel_version.hpp
+++ b/include/uring/utility/kernel_version.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #ifndef LIBURINGCXX_KERNEL_VERSION_MAJOR
-#error Fail to detect kernel version. Please check CMakeLists.txt (at root level).
+#error Fail to detect kernel version. Please check cmake/Platform.cmake .
 #endif
 
 #ifndef LIBURINGCXX_KERNEL_VERSION_MINOR
-#error Fail to detect kernel version. Please check CMakeLists.txt (at root level).
+#error Fail to detect kernel version. Please check cmake/Platform.cmake .
 #endif
 
 namespace liburingcxx {


### PR DESCRIPTION
- The missing linux header `<linux/openat2.h>` will not fail the compilation now. Instead, `openat2` will be removed from liburingcxx.