### PR TITLE
Fix: compat for cross-compiling & RISC-V

### DIFF
--- a/cmake/CompileOption.cmake
+++ b/cmake/CompileOption.cmake
@@ -14,7 +14,7 @@ if(NOT CMAKE_BUILD_TYPE)
     message(NOTICE "Setting default CMAKE_BUILD_TYPE to Release")
 endif()
 
-if(CMAKE_BUILD_TYPE MATCHES Release)
+if(CMAKE_BUILD_TYPE MATCHES Release AND NOT CMAKE_CROSSCOMPILING)
     target_compile_options(co_context PUBLIC -march=native)
 endif()
 

--- a/include/co_context/config.hpp
+++ b/include/co_context/config.hpp
@@ -108,8 +108,7 @@ namespace config {
     // ========================================================================
 
     // ========================== net configuration ===========================
-    inline constexpr bool is_loopback_only = true;
-    // inline constexpr bool is_loopback_only = false;
+    inline constexpr bool is_loopback_only = false;
     // ========================================================================
 
     // =========================== co configuration ===========================

--- a/include/co_context/detail/compat.hpp
+++ b/include/co_context/detail/compat.hpp
@@ -9,11 +9,15 @@
 #endif
 
 #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
-#define CO_CONTEXT_PAUSE __builtin_ia32_pause
+#if defined(__i386__) || defined(__x86_64__)
+#define CO_CONTEXT_PAUSE() __builtin_ia32_pause()
+#elif defined(__riscv)
+#define CO_CONTEXT_PAUSE() __asm__ volatile("fence iorw, iorw")
+#endif
 #elif defined(_MSC_VER)
-#define CO_CONTEXT_PAUSE _mm_pause
+#define CO_CONTEXT_PAUSE() _mm_pause()
 #else
-#define CO_CONTEXT_PAUSE __builtin_ia32_pause
+#define CO_CONTEXT_PAUSE() __builtin_ia32_pause()
 #endif
 
 #if (defined(__GNUC__) || defined(__GNUG__)) \

--- a/include/co_context/detail/spsc_cursor.hpp
+++ b/include/co_context/detail/spsc_cursor.hpp
@@ -14,7 +14,7 @@ template<
     bool is_blocking = is_thread_safe>
 struct spsc_cursor {
     static_assert(std::has_single_bit(capacity));
-    static_assert(std::atomic<T>::is_always_lock_free);
+    static_assert(!is_thread_safe || std::atomic<T>::is_always_lock_free);
     static_assert(
         is_thread_safe || !is_blocking,
         "a thread-unsafe instance "


### PR DESCRIPTION
Big thanks to @wangzhankun who helps to cross-compiling on RISC-V architecture:
1. No more `atomic<uint16_t>::is_always_lock_free` requirement on any architecture. (#88)
2. Fix [compat.hpp](https://github.com/Codesire-Deng/co_context/blob/main/include/co_context/detail/compat.hpp) for RISC-V. (#88)
3. Disable `-march=native` when cross-compiling. (#88)
4. No `is_loopback_only(INADDR_LOOPBACK)` by default. (#91)