### PR TITLE
feat(uring): compat kernel without `__kernel_timespec`. Thanks to Lawliet828

### DIFF
--- a/include/co_context/config.hpp
+++ b/include/co_context/config.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <uring/compat.hpp>
 #include <uring/io_uring.h>
 #include <uring/uring_define.hpp>
 #include <uring/utility/kernel_version.hpp>
@@ -137,9 +138,9 @@ namespace config {
     enum class level : uint8_t { verbose, debug, info, warning, error, no_log };
 
     // inline constexpr level log_level = level::verbose;
-    // inline constexpr level log_level = level::debug;
+    inline constexpr level log_level = level::debug;
     // inline constexpr level log_level = level::info;
-    inline constexpr level log_level = level::warning;
+    // inline constexpr level log_level = level::warning;
     // inline constexpr level log_level = level::error;
     // inline constexpr level log_level = level::no_log;
 

--- a/include/co_context/utility/time_cast.hpp
+++ b/include/co_context/utility/time_cast.hpp
@@ -3,7 +3,6 @@
 #include <co_context/config.hpp>
 
 #include <chrono>
-#include <linux/time_types.h>
 
 namespace co_context {
 

--- a/include/uring/compat.hpp
+++ b/include/uring/compat.hpp
@@ -1,6 +1,20 @@
 #pragma once
 
+#if __has_include(<linux/time_types.h>)
 #include <linux/time_types.h>
+/* <linux/time_types.h> is included above and not needed again */
+#define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H 1
+#else
+#include <cstdint>
+
+struct __kernel_timespec {
+	int64_t		tv_sec;
+	long long	tv_nsec;
+};
+
+/* <linux/time_types.h> is not available, so it can't be included */
+#define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H 1
+#endif
 
 #if __has_include(<linux/openat2.h>)
 #include <linux/openat2.h>


### PR DESCRIPTION
feat(uring): compat kernel without `__kernel_timespec`. Thanks to @Lawliet828 . (#97)